### PR TITLE
Merge Jit + proper cosimulation into main (x2.5 speedup)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = clang++
 INCLUDE = -I../ELFIOgit
-CFLAGS = -Wno-initializer-overrides -Wno-c99-designator -O3 $(INCLUDE) `llvm-config --cppflags --ldflags --libs` 
+CFLAGS = -Wno-initializer-overrides -Wno-c99-designator -O3 -MMD -MP $(INCLUDE) -Wno-unused-command-line-argument `llvm-config --cppflags --ldflags --libs`
 BUILDDIR = build
 SRCDIR = .
 
@@ -31,5 +31,7 @@ mkdir:
 clean:
 	rm -rf $(BUILDDIR)
 
-run:
+run: simulator
 	$(BUILDDIR)/simulator
+
+-include $(OBJS:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,27 @@ CC = clang++
 INCLUDE = -I../ELFIOgit
 CFLAGS = -Wno-initializer-overrides -Wno-c99-designator -O3 $(INCLUDE) `llvm-config --cppflags --ldflags --libs` 
 BUILDDIR = build
+SRCDIR = .
+
+SRCS = $(wildcard $(SRCDIR)/*.cpp)
+OBJS = $(addprefix $(BUILDDIR)/,$(SRCS:$(SRCDIR)/%.cpp=%.o))
 
 XCC = $(shell ./detect_xcompiler.sh)
 XCFLAGS = -nostdlib -march=rv64i -mabi=lp64
 
-all: mkdir sample 8queens
-	$(CC) $(CFLAGS) main.cpp instruction.cpp mask.cpp basic_block.cpp hart.cpp -o $(BUILDDIR)/simulator
+all: mkdir sample 8queens simulator
 
-sample:
+simulator: $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -o $(BUILDDIR)/simulator
+
+$(BUILDDIR)/%.o: $(SRCDIR)/%.cpp
+	@mkdir -p $(BUILDDIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+sample: sample_rv64.s
 	$(XCC) $(XCFLAGS) sample_rv64.s -o $(BUILDDIR)/sample_rv64
 
-8queens:
+8queens: 8queens.c
 	$(XCC) $(XCFLAGS) 8queens.c -o $(BUILDDIR)/8queens
 
 mkdir:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = clang++
 INCLUDE = -I../ELFIOgit
-CFLAGS = -Wno-initializer-overrides -Wno-c99-designator -O3 $(INCLUDE)
+CFLAGS = -Wno-initializer-overrides -Wno-c99-designator -O3 $(INCLUDE) `llvm-config --cppflags --ldflags --libs` 
 BUILDDIR = build
 
 XCC = $(shell ./detect_xcompiler.sh)

--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,5 @@ mkdir:
 clean:
 	rm -rf $(BUILDDIR)
 
-run:
+run: all
 	$(BUILDDIR)/simulator

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -1,8 +1,11 @@
+#include "llvm/ExecutionEngine/Interpreter.h"
+#include "llvm/IR/Verifier.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/TargetSelect.h"
+#include <string>
 
 #include "instruction.hpp"
 #include "hart.hpp"
@@ -20,6 +23,7 @@ static llvm::FunctionType *jit_ft;
 void RVBasicBlock::init() {
     InitializeNativeTarget();
     InitializeNativeTargetAsmPrinter();
+    InitializeNativeTargetAsmParser();
 
     jit = LLJITBuilder().create();
     if (!jit) {
@@ -27,7 +31,7 @@ void RVBasicBlock::init() {
         exit(1);
     }
     jit_ft = FunctionType::get(Type::getVoidTy(ctx), 
-       {Type::getInt64PtrTy(ctx), Type::getInt8Ty(ctx), Type::getInt64PtrTy(ctx)}, false);
+       {Type::getInt64PtrTy(ctx), Type::getInt8Ty(ctx), Type::getInt64PtrTy(ctx), Type::getInt1PtrTy(ctx)}, false);
 }
 
 size_t RVBasicBlock::construct(const instT *arr) {
@@ -57,15 +61,19 @@ size_t RVBasicBlock::construct(const instT *arr) {
 }
 
 size_t RVBasicBlock::do_jit(const instT *arr) {
-    auto module = std::make_unique<Module>("", ctx);
-    Function* fn = Function::Create(jit_ft, Function::ExternalLinkage, "jit", module.get());
+    static int cnt = 0;
+    cnt++;
+    const std::string name = std::to_string(cnt);
+    auto module = std::make_unique<Module>(name, ctx);
+    Function* fn = Function::Create(jit_ft, Function::ExternalLinkage, name, module.get());
     BasicBlock* block = BasicBlock::Create(ctx, "", fn);
     IRBuilder<> builder(block);
 
     auto args = fn->args().begin();
     Value* regs = &*args++;
     Value* mem = &*args++;
-    Value* pc = &*args;
+    Value* pc = &*args++;
+    Value* done = &*args;
     Value* new_pc = builder.CreateAlloca(Type::getInt64Ty(ctx), 0, "new_pc");
 
     int i = 0;
@@ -81,7 +89,7 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         auto dec = decoders[fingerprint];
         DEB("decoding..");
         dec.decod(instrs[i], instruction);
-        dec.jit(instrs[i], builder, ctx, regs, mem, pc, new_pc, fn);
+        dec.jit(instrs[i], builder, ctx, regs, mem, pc, new_pc, fn, done);
         if (!dec.linear) {
             len = i + 1;
             break;
@@ -93,19 +101,30 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         len = BB_len+1;
     }
     module->print(outs(), nullptr);
+    std::cout << "printed\n";
+
+    bool verif = verifyModule(*module, &outs());
+    outs() << "[VERIFICATION] " << (!verif ? "OK\n\n" : "FAIL\n\n");
+
+
+
     if (auto err = jit->get()->addIRModule(ThreadSafeModule(std::move(module), std::make_unique<LLVMContext>()))) {
         std::cerr << "Failed to add module to LLJIT: " << toString(std::move(err)) << std::endl;
         return 1;
     }
 
+    std::cout << jit->get() << " no err\n";
     // Look up the JIT'd function, cast it to a function pointer, then call it.
-    auto jit_func_sym = jit->get()->lookup("jit");
+    auto jit_func_sym = jit->get()->lookup(name);
+    std::cout << jit->get() << " no err\n";
     if (!jit_func_sym) {
         std::cerr << "Failed to look up function: " << toString(jit_func_sym.takeError()) << std::endl;
         return 1;
     }
 
+    std::cout << "looked up\n";
     // Cast the symbol's address to a function pointer and call it.
     jitted = jit_func_sym->toPtr<BBFType>();
+    std::cout << "casted\n";
     return BB_len+1;
 }

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -100,12 +100,13 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         instrs[BB_len].execute = Executors::empty_executor;
         len = BB_len+1;
     }
+#ifdef DEBUG
     module->print(outs(), nullptr);
-    std::cout << "printed\n";
+    DEB("printed");
 
     bool verif = verifyModule(*module, &outs());
     outs() << "[VERIFICATION] " << (!verif ? "OK\n\n" : "FAIL\n\n");
-
+#endif
 
 
     if (auto err = jit->get()->addIRModule(ThreadSafeModule(std::move(module), std::make_unique<LLVMContext>()))) {
@@ -113,18 +114,18 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         return 1;
     }
 
-    std::cout << jit->get() << " no err\n";
+    DEB(jit->get() << " no err");
     // Look up the JIT'd function, cast it to a function pointer, then call it.
     auto jit_func_sym = jit->get()->lookup(name);
-    std::cout << jit->get() << " no err\n";
+    DEB(jit->get() << " no err");
     if (!jit_func_sym) {
         std::cerr << "Failed to look up function: " << toString(jit_func_sym.takeError()) << std::endl;
         return 1;
     }
 
-    std::cout << "looked up\n";
+    DEB("looked up");
     // Cast the symbol's address to a function pointer and call it.
     jitted = jit_func_sym->toPtr<BBFType>();
-    std::cout << "casted\n";
+    DEB("casted");
     return BB_len+1;
 }

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -100,13 +100,11 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         instrs[BB_len].execute = Executors::empty_executor;
         len = BB_len+1;
     }
-#ifdef DEBUG
     module->print(outs(), nullptr);
     DEB("printed");
 
     bool verif = verifyModule(*module, &outs());
     outs() << "[VERIFICATION] " << (!verif ? "OK\n\n" : "FAIL\n\n");
-#endif
 
 
     if (auto err = jit->get()->addIRModule(ThreadSafeModule(std::move(module), std::make_unique<LLVMContext>()))) {

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -75,7 +75,6 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
     Value* mem = &*args++;
     Value* pc = &*args++;
     Value* done = &*args;
-    Value* new_pc = builder.CreateAlloca(Type::getInt64Ty(ctx), 0, "new_pc");
 
     int i = 0;
     for (; i < BB_len; i++) {
@@ -90,7 +89,7 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         auto dec = decoders[fingerprint];
         DEB("decoding..");
         dec.decod(instrs[i], instruction);
-        dec.jit(instrs[i], builder, ctx, regs, mem, pc, new_pc, fn, done);
+        dec.jit(instrs[i], builder, ctx, regs, mem, pc, fn, done);
         if (!dec.linear) {
             len = i + 1;
             break;

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -5,6 +5,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/TargetSelect.h"
+#include <llvm-16/llvm/IR/DerivedTypes.h>
 #include <string>
 
 #include "instruction.hpp"
@@ -31,7 +32,7 @@ void RVBasicBlock::init() {
         exit(1);
     }
     jit_ft = FunctionType::get(Type::getVoidTy(ctx), 
-       {Type::getInt64PtrTy(ctx), Type::getInt8Ty(ctx), Type::getInt64PtrTy(ctx), Type::getInt1PtrTy(ctx)}, false);
+       {Type::getInt64PtrTy(ctx), Type::getInt8PtrTy(ctx), Type::getInt64PtrTy(ctx), Type::getInt1PtrTy(ctx) }, false);
 }
 
 size_t RVBasicBlock::construct(const instT *arr) {

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -1,10 +1,32 @@
-#include "basic_block.hpp"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/TargetSelect.h"
+
 #include "instruction.hpp"
 #include "hart.hpp"
+#include "basic_block.hpp"
 
-BasicBlock bbs_arr[BB_arr_mask+1] = {};
+using namespace llvm;
+using namespace llvm::orc;
 
-size_t BasicBlock::construct(const instT *arr) {
+RVBasicBlock bbs_arr[BB_arr_mask+1] = {};
+
+void RVBasicBlock::init() {
+    InitializeNativeTarget();
+    InitializeNativeTargetAsmPrinter();
+
+    jit = LLJITBuilder().create();
+    if (!jit) {
+        std::cerr << "Failed to create LLJIT: " << toString(jit.takeError()) << std::endl;
+        exit(1);
+    }
+    jit_ft = FunctionType::get(Type::getVoidTy(ctx), 
+       {Type::getInt64PtrTy(ctx), Type::getInt8Ty(ctx), Type::getInt64PtrTy(ctx)}, false);
+}
+
+size_t RVBasicBlock::construct(const instT *arr) {
     int i = 0;
     for (; i < BB_len; i++) {
         DEB("bb:" << i);
@@ -27,5 +49,58 @@ size_t BasicBlock::construct(const instT *arr) {
     DEB("decoded\n");
     instrs[BB_len].execute = Executors::empty_executor;
     len = BB_len+1;
+    return BB_len+1;
+}
+
+size_t RVBasicBlock::do_jit(const instT *arr) {
+    auto module = std::make_unique<Module>("", ctx);
+    Function* fn = Function::Create(jit_ft, Function::ExternalLinkage, "jit", module.get());
+    BasicBlock* block = BasicBlock::Create(ctx, "", fn);
+    IRBuilder<> builder(block);
+
+    auto args = fn->args().begin();
+    Value* regs = &*args++;
+    Value* mem = &*args++;
+    Value* pc = &*args;
+    Value* new_pc = builder.CreateAlloca(Type::getInt64Ty(ctx), 0, "new_pc");
+
+    int i = 0;
+    for (; i < BB_len; i++) {
+        DEB("bb:" << i);
+        const instT &instruction = arr[i];
+        DEB("bb:" << instruction);
+        uint32_t fingerprint = instruction & mask[instruction & 127];
+        DEB("bb:" << i);
+        fingerprint = FP_HASH(fingerprint);
+
+        DEB("reading...");
+        auto dec = decoders[fingerprint];
+        DEB("decoding..");
+        dec.decod(instrs[i], instruction);
+        dec.jit(instrs[i], builder);
+        if (!dec.linear) {
+            len = i + 1;
+            break;
+        }
+    }
+    if (i==BB_len) {
+        DEB("decoded\n");
+        instrs[BB_len].execute = Executors::empty_executor;
+        len = BB_len+1;
+    }
+    if (auto err = jit->get()->addIRModule(ThreadSafeModule(std::move(module), std::make_unique<LLVMContext>()))) {
+        std::cerr << "Failed to add module to LLJIT: " << toString(std::move(err)) << std::endl;
+        return 1;
+    }
+
+    // Look up the JIT'd function, cast it to a function pointer, then call it.
+    auto jit_func_sym = jit->get()->lookup("jit");
+    if (!jit_func_sym) {
+        std::cerr << "Failed to look up function: " << toString(jit_func_sym.takeError()) << std::endl;
+        return 1;
+    }
+
+    // Cast the symbol's address to a function pointer and call it.
+    BBFType jit_func = jit_func_sym->toPtr<BBFType>();
     return BB_len+1;
 }

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -15,8 +15,6 @@
 using namespace llvm;
 using namespace llvm::orc;
 
-RVBasicBlock bbs_arr[BB_arr_mask+1] = {};
-
 static llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> jit = nullptr;
 static llvm::LLVMContext ctx;
 static llvm::FunctionType *jit_ft;
@@ -49,6 +47,7 @@ size_t RVBasicBlock::construct(const instT *arr) {
         auto dec = decoders[fingerprint];
         DEB("decoding..");
         dec.decod(instrs[i], instruction);
+        instrs[i].dump();
         instrs[i].execute = dec.exec;
         if (!dec.linear) {
             len = i + 1;
@@ -90,6 +89,7 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         DEB("decoding..");
         dec.decod(instrs[i], instruction);
         dec.jit(instrs[i], builder, ctx, regs, mem, pc, fn, done);
+        instrs[i].dump();
         if (!dec.linear) {
             len = i + 1;
             break;
@@ -97,7 +97,7 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
     }
     if (i==BB_len) {
         DEB("decoded\n");
-        instrs[BB_len].execute = Executors::empty_executor;
+        Jiters::empty_jiter(builder);
         len = BB_len+1;
     }
     module->print(outs(), nullptr);

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -47,7 +47,9 @@ size_t RVBasicBlock::construct(const instT *arr) {
         auto dec = decoders[fingerprint];
         DEB("decoding..");
         dec.decod(instrs[i], instruction);
+#ifdef DEBUG
         instrs[i].dump();
+#endif
         instrs[i].execute = dec.exec;
         if (!dec.linear) {
             len = i + 1;
@@ -89,7 +91,9 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         DEB("decoding..");
         dec.decod(instrs[i], instruction);
         dec.jit(instrs[i], builder, ctx, regs, mem, pc, fn, done);
+#ifdef DEBUG
         instrs[i].dump();
+#endif
         if (!dec.linear) {
             len = i + 1;
             break;
@@ -100,11 +104,13 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         Jiters::empty_jiter(builder);
         len = BB_len+1;
     }
+#ifdef DEBUG
     module->print(outs(), nullptr);
+#endif
     DEB("printed");
 
     bool verif = verifyModule(*module, &outs());
-    outs() << "[VERIFICATION] " << (!verif ? "OK\n\n" : "FAIL\n\n");
+    DEB("[VERIFICATION] " << (!verif ? "OK\n\n" : "FAIL\n"));
 
 
     if (auto err = jit->get()->addIRModule(ThreadSafeModule(std::move(module), std::make_unique<LLVMContext>()))) {

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -29,8 +29,11 @@ void RVBasicBlock::init() {
         std::cerr << "Failed to create LLJIT: " << toString(jit.takeError()) << std::endl;
         exit(1);
     }
-    jit_ft = FunctionType::get(Type::getVoidTy(ctx), 
-       {Type::getInt64PtrTy(ctx), Type::getInt8PtrTy(ctx), Type::getInt64PtrTy(ctx), Type::getInt1PtrTy(ctx) }, false);
+    jit_ft =
+        FunctionType::get(Type::getVoidTy(ctx),
+                          {Type::getInt64PtrTy(ctx), Type::getInt8PtrTy(ctx),
+                           Type::getInt64PtrTy(ctx), Type::getInt1PtrTy(ctx)},
+                          false);
 }
 
 size_t RVBasicBlock::construct(const instT *arr) {
@@ -74,8 +77,10 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
     auto args = fn->args().begin();
     Value* regs = &*args++;
     Value* mem = &*args++;
-    Value* pc = &*args++;
+    Value* pc_ptr = &*args++;
     Value* done = &*args;
+
+    Value *pc_val = builder.CreateLoad(Type::getInt64Ty(ctx), pc_ptr, "pc");
 
     int i = 0;
     for (; i < BB_len; i++) {
@@ -90,20 +95,16 @@ size_t RVBasicBlock::do_jit(const instT *arr) {
         auto dec = decoders[fingerprint];
         DEB("decoding..");
         dec.decod(instrs[i], instruction);
-        dec.jit(instrs[i], builder, ctx, regs, mem, pc, fn, done);
+        pc_val = dec.jit(instrs[i], builder, ctx, regs, mem, pc_val, fn, done);
 #ifdef DEBUG
         instrs[i].dump();
 #endif
-        if (!dec.linear) {
-            len = i + 1;
+        if (!dec.linear)
             break;
-        }
     }
-    if (i==BB_len) {
-        DEB("decoded\n");
-        Jiters::empty_jiter(builder);
-        len = BB_len+1;
-    }
+    len = i + 1;
+    Jiters::empty_jiter(builder, pc_val, pc_ptr);
+
 #ifdef DEBUG
     module->print(outs(), nullptr);
 #endif

--- a/basic_block.cpp
+++ b/basic_block.cpp
@@ -1,40 +1,6 @@
-#include "llvm/ExecutionEngine/Interpreter.h"
-#include "llvm/IR/Verifier.h"
-#include "llvm/ExecutionEngine/Orc/LLJIT.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
-#include "llvm/Support/TargetSelect.h"
-#include <llvm-16/llvm/IR/DerivedTypes.h>
-#include <string>
-
 #include "instruction.hpp"
 #include "hart.hpp"
 #include "basic_block.hpp"
-
-using namespace llvm;
-using namespace llvm::orc;
-
-static llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> jit = nullptr;
-static llvm::LLVMContext ctx;
-static llvm::FunctionType *jit_ft;
-
-void RVBasicBlock::init() {
-    InitializeNativeTarget();
-    InitializeNativeTargetAsmPrinter();
-    InitializeNativeTargetAsmParser();
-
-    jit = LLJITBuilder().create();
-    if (!jit) {
-        std::cerr << "Failed to create LLJIT: " << toString(jit.takeError()) << std::endl;
-        exit(1);
-    }
-    jit_ft =
-        FunctionType::get(Type::getVoidTy(ctx),
-                          {Type::getInt64PtrTy(ctx), Type::getInt8PtrTy(ctx),
-                           Type::getInt64PtrTy(ctx), Type::getInt1PtrTy(ctx)},
-                          false);
-}
 
 size_t RVBasicBlock::construct(const instT *arr) {
     int i = 0;
@@ -62,75 +28,5 @@ size_t RVBasicBlock::construct(const instT *arr) {
     DEB("decoded\n");
     instrs[BB_len].execute = Executors::empty_executor;
     len = BB_len+1;
-    return BB_len+1;
-}
-
-size_t RVBasicBlock::do_jit(const instT *arr) {
-    static int cnt = 0;
-    cnt++;
-    const std::string name = std::to_string(cnt);
-    auto module = std::make_unique<Module>(name, ctx);
-    Function* fn = Function::Create(jit_ft, Function::ExternalLinkage, name, module.get());
-    BasicBlock* block = BasicBlock::Create(ctx, "", fn);
-    IRBuilder<> builder(block);
-
-    auto args = fn->args().begin();
-    Value* regs = &*args++;
-    Value* mem = &*args++;
-    Value* pc_ptr = &*args++;
-    Value* done = &*args;
-
-    Value *pc_val = builder.CreateLoad(Type::getInt64Ty(ctx), pc_ptr, "pc");
-
-    int i = 0;
-    for (; i < BB_len; i++) {
-        DEB("bb:" << i);
-        const instT &instruction = arr[i];
-        DEB("bb:" << instruction);
-        uint32_t fingerprint = instruction & mask[instruction & 127];
-        DEB("bb:" << i);
-        fingerprint = FP_HASH(fingerprint);
-
-        DEB("reading...");
-        auto dec = decoders[fingerprint];
-        DEB("decoding..");
-        dec.decod(instrs[i], instruction);
-        pc_val = dec.jit(instrs[i], builder, ctx, regs, mem, pc_val, fn, done);
-#ifdef DEBUG
-        instrs[i].dump();
-#endif
-        if (!dec.linear)
-            break;
-    }
-    len = i + 1;
-    Jiters::empty_jiter(builder, pc_val, pc_ptr);
-
-#ifdef DEBUG
-    module->print(outs(), nullptr);
-#endif
-    DEB("printed");
-
-    bool verif = verifyModule(*module, &outs());
-    DEB("[VERIFICATION] " << (!verif ? "OK\n\n" : "FAIL\n"));
-
-
-    if (auto err = jit->get()->addIRModule(ThreadSafeModule(std::move(module), std::make_unique<LLVMContext>()))) {
-        std::cerr << "Failed to add module to LLJIT: " << toString(std::move(err)) << std::endl;
-        return 1;
-    }
-
-    DEB(jit->get() << " no err");
-    // Look up the JIT'd function, cast it to a function pointer, then call it.
-    auto jit_func_sym = jit->get()->lookup(name);
-    DEB(jit->get() << " no err");
-    if (!jit_func_sym) {
-        std::cerr << "Failed to look up function: " << toString(jit_func_sym.takeError()) << std::endl;
-        return 1;
-    }
-
-    DEB("looked up");
-    // Cast the symbol's address to a function pointer and call it.
-    jitted = jit_func_sym->toPtr<BBFType>();
-    DEB("casted");
     return BB_len+1;
 }

--- a/basic_block.hpp
+++ b/basic_block.hpp
@@ -20,6 +20,7 @@ class RVBasicBlock {
 public:
     typedef void (*BBFType)(uint64_t *regs, uint8_t *mem, size_t *pc);
     size_t addr;
+    BBFType jitted;
     Instruction instrs[BB_len+1]; // +1 is reserved for empty
     uint8_t len;
 
@@ -27,9 +28,6 @@ public:
     size_t construct(const instT *arr);
     size_t do_jit(const instT *arr);
 
-    static llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> jit;
-    static llvm::LLVMContext ctx;
-    static llvm::FunctionType *jit_ft;
 //    static llvm::Type *ptrType;
 };
 

--- a/basic_block.hpp
+++ b/basic_block.hpp
@@ -18,7 +18,7 @@ const size_t BB_arr_mask = (1<<17)-1; // TODO it's 90MB, maybe more?
 
 class RVBasicBlock {
 public:
-    typedef void (*BBFType)(uint64_t *regs, uint8_t *mem, size_t *pc);
+    typedef void (*BBFType)(uint64_t *regs, uint8_t *mem, size_t *pc, bool *done);
     size_t addr;
     BBFType jitted;
     Instruction instrs[BB_len+1]; // +1 is reserved for empty

--- a/basic_block.hpp
+++ b/basic_block.hpp
@@ -1,22 +1,38 @@
 #ifndef BB_H
 #define BB_H
 
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/TargetSelect.h"
+
 #include "instruction.hpp"
 #include "mask.hpp"
 #include <cstdint>
+#include <llvm-16/llvm/IR/DerivedTypes.h>
+#include <llvm-16/llvm/IR/Type.h>
 
 const size_t BB_len = 31;
 const size_t BB_arr_mask = (1<<17)-1; // TODO it's 90MB, maybe more?
 
-class BasicBlock {
+class RVBasicBlock {
 public:
+    typedef void (*BBFType)(uint64_t *regs, uint8_t *mem, size_t *pc);
     size_t addr;
     Instruction instrs[BB_len+1]; // +1 is reserved for empty
     uint8_t len;
 
+    static void init();
     size_t construct(const instT *arr);
+    size_t do_jit(const instT *arr);
+
+    static llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> jit;
+    static llvm::LLVMContext ctx;
+    static llvm::FunctionType *jit_ft;
+//    static llvm::Type *ptrType;
 };
 
-extern BasicBlock bbs_arr[BB_arr_mask+1];
+extern RVBasicBlock bbs_arr[BB_arr_mask+1];
 
 #endif // BB_H

--- a/basic_block.hpp
+++ b/basic_block.hpp
@@ -1,36 +1,20 @@
 #ifndef BB_H
 #define BB_H
 
-#include "llvm/ExecutionEngine/Orc/LLJIT.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
-#include "llvm/Support/TargetSelect.h"
-
 #include "instruction.hpp"
 #include "mask.hpp"
 #include <cstdint>
-#include <llvm-16/llvm/IR/DerivedTypes.h>
-#include <llvm-16/llvm/IR/Type.h>
 
 const size_t BB_len = 31; // 1 for cosim, 31 is good enough for run
 const size_t BB_arr_mask = (1<<17)-1; // TODO it's 90MB, maybe more?
 
 class RVBasicBlock {
 public:
-    typedef void (*BBFType)(uint64_t *regs, uint8_t *mem, size_t *pc, bool *done);
     size_t addr;
-    BBFType jitted;
     Instruction instrs[BB_len+1]; // +1 is reserved for empty
     uint8_t len;
 
-    static void init();
     size_t construct(const instT *arr);
-    size_t do_jit(const instT *arr);
-
-//    static llvm::Type *ptrType;
 };
-
-extern RVBasicBlock bbs_arr[BB_arr_mask+1];
 
 #endif // BB_H

--- a/basic_block.hpp
+++ b/basic_block.hpp
@@ -13,7 +13,7 @@
 #include <llvm-16/llvm/IR/DerivedTypes.h>
 #include <llvm-16/llvm/IR/Type.h>
 
-const size_t BB_len = 1; // 1 for cosim, 31 is good enough for run
+const size_t BB_len = 31; // 1 for cosim, 31 is good enough for run
 const size_t BB_arr_mask = (1<<17)-1; // TODO it's 90MB, maybe more?
 
 class RVBasicBlock {

--- a/basic_block.hpp
+++ b/basic_block.hpp
@@ -5,7 +5,7 @@
 #include "mask.hpp"
 #include <cstdint>
 
-const size_t BB_len = 31;
+const size_t BB_len = 1;
 const size_t BB_arr_mask = (1<<17)-1; // TODO it's 90MB, maybe more?
 
 class BasicBlock {

--- a/basic_block.hpp
+++ b/basic_block.hpp
@@ -5,7 +5,7 @@
 #include "mask.hpp"
 #include <cstdint>
 
-const size_t BB_len = 1;
+const size_t BB_len = 31; // 1 for cosim, 31 is good enough for run
 const size_t BB_arr_mask = (1<<17)-1; // TODO it's 90MB, maybe more?
 
 class BasicBlock {

--- a/basic_block.hpp
+++ b/basic_block.hpp
@@ -13,7 +13,7 @@
 #include <llvm-16/llvm/IR/DerivedTypes.h>
 #include <llvm-16/llvm/IR/Type.h>
 
-const size_t BB_len = 31; // 1 for cosim, 31 is good enough for run
+const size_t BB_len = 1; // 1 for cosim, 31 is good enough for run
 const size_t BB_arr_mask = (1<<17)-1; // TODO it's 90MB, maybe more?
 
 class RVBasicBlock {

--- a/elf_reader.hpp
+++ b/elf_reader.hpp
@@ -54,7 +54,6 @@ class ElfReader {
             vmem_size = vmem_max_addr + 1;
 
             vmem_ = new uint8_t[vmem_size];
-            std::cout << "VMEM_ " << (void*)vmem_ << '\n';
             if (!vmem_) {
                 return ReaderStatus::BAD_ALLOC;
             }

--- a/hart.cpp
+++ b/hart.cpp
@@ -1,20 +1,24 @@
 #include "hart.hpp"
 #include "instruction.hpp"
+#include "basic_block.hpp"
 
 EXECUTE_STATUS Hart::simulate() {
     EXECUTE_STATUS status = EXECUTE_STATUS::SUCCESS;
     // execute
     while (!done) {
         DEB("decoding at pc=" << pc);
-        BasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
+        RVBasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
         if (bb.addr == pc) {
-            bb.instrs[0].execute(this, bb.instrs[0]);
-            ins_cnt += bb.len;
+            bb.jitted(this->registers.data(), this->memory, &this->pc);
+//            bb.instrs[0].execute(this, bb.instrs[0]);
+//            ins_cnt += bb.len;
         }
         else {
-            bb.construct((instT*)(memory+pc));
+            bb.do_jit((instT*)(memory+pc));
+//            bb.construct((instT*)(memory+pc));
             bb.addr = pc;
-            bb.instrs[0].execute(this, bb.instrs[0]);
+            bb.jitted(this->registers.data(), this->memory, &this->pc);
+//            bb.instrs[0].execute(this, bb.instrs[0]);
             ins_cnt += bb.len;
         }
     }

--- a/hart.cpp
+++ b/hart.cpp
@@ -8,6 +8,7 @@ EXECUTE_STATUS Hart::simulate() {
     while (!done) {
         DEB("decoding at pc=" << pc);
         RVBasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
+        std::cout << "decoding at pc=" << pc << '\n';
         if (bb.addr == pc) {
             bb.jitted(this->registers.data(), this->memory, &this->pc, &this->done);
 //            bb.instrs[0].execute(this, bb.instrs[0]);

--- a/hart.cpp
+++ b/hart.cpp
@@ -7,7 +7,7 @@ EXECUTE_STATUS Hart::simulate() {
     // execute
     while (!done) {
         DEB("decoding at pc=" << pc);
-        std::cout << "dec at pc= "  << pc << '\n';
+//        std::cout << "dec at pc= "  << pc << '\n';
         RVBasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
         if (bb.addr == pc) {
             bb.jitted(this->registers.data(), this->memory, &this->pc, &this->done);

--- a/hart.cpp
+++ b/hart.cpp
@@ -7,17 +7,21 @@ EXECUTE_STATUS Hart::simulate() {
     // execute
     while (!done) {
         DEB("decoding at pc=" << pc);
+        std::cout << "dec at pc= "  << pc << '\n';
         RVBasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
         if (bb.addr == pc) {
-            bb.jitted(this->registers.data(), this->memory, &this->pc);
+            bb.jitted(this->registers.data(), this->memory, &this->pc, &this->done);
 //            bb.instrs[0].execute(this, bb.instrs[0]);
 //            ins_cnt += bb.len;
         }
         else {
+            std::cout << "jitting\n";
             bb.do_jit((instT*)(memory+pc));
+            std::cout << "jitted\n";
 //            bb.construct((instT*)(memory+pc));
             bb.addr = pc;
-            bb.jitted(this->registers.data(), this->memory, &this->pc);
+            bb.jitted(this->registers.data(), this->memory, &this->pc, &this->done);
+            std::cout << pc << "runned\n";
 //            bb.instrs[0].execute(this, bb.instrs[0]);
             ins_cnt += bb.len;
         }

--- a/hart.cpp
+++ b/hart.cpp
@@ -7,21 +7,20 @@ EXECUTE_STATUS Hart::simulate() {
     // execute
     while (!done) {
         DEB("decoding at pc=" << pc);
-//        std::cout << "dec at pc= "  << pc << '\n';
         RVBasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
         if (bb.addr == pc) {
             bb.jitted(this->registers.data(), this->memory, &this->pc, &this->done);
 //            bb.instrs[0].execute(this, bb.instrs[0]);
-//            ins_cnt += bb.len;
+            ins_cnt += bb.len;
         }
         else {
-            std::cout << "jitting\n";
+            DEB("jitting");
             bb.do_jit((instT*)(memory+pc));
-            std::cout << "jitted\n";
+            DEB("jitted");
 //            bb.construct((instT*)(memory+pc));
             bb.addr = pc;
             bb.jitted(this->registers.data(), this->memory, &this->pc, &this->done);
-            std::cout << pc << "runned\n";
+            DEB(pc << "runned");
 //            bb.instrs[0].execute(this, bb.instrs[0]);
             ins_cnt += bb.len;
         }

--- a/hart.cpp
+++ b/hart.cpp
@@ -5,9 +5,8 @@
 
 EXECUTE_STATUS Hart::simulate() {
     EXECUTE_STATUS status = EXECUTE_STATUS::SUCCESS;
-    while (!done) {
+    while (!done)
         exec_instr();
-    }
     return EXECUTE_STATUS::SUCCESS;
 }
 

--- a/hart.cpp
+++ b/hart.cpp
@@ -6,17 +6,7 @@ EXECUTE_STATUS Hart::simulate() {
     // execute
     while (!done) {
         DEB("decoding at pc=" << pc);
-        BasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
-        if (bb.addr == pc) {
-            bb.instrs[0].execute(this, bb.instrs[0]);
-            ins_cnt += bb.len;
-        }
-        else {
-            bb.construct((instT*)(memory+pc));
-            bb.addr = pc;
-            bb.instrs[0].execute(this, bb.instrs[0]);
-            ins_cnt += bb.len;
-        }
+        exec_instr();
     }
     return EXECUTE_STATUS::SUCCESS;
 }

--- a/hart.cpp
+++ b/hart.cpp
@@ -21,7 +21,7 @@ EXECUTE_STATUS Hart::simulate() {
     return EXECUTE_STATUS::SUCCESS;
 }
 
-EXECUTE_STATUS Hart::exec_instr() {
+void Hart::exec_instr() {
     BasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
     if (bb.addr == pc) {
         bb.instrs[0].execute(this, bb.instrs[0]);
@@ -33,5 +33,4 @@ EXECUTE_STATUS Hart::exec_instr() {
         bb.instrs[0].execute(this, bb.instrs[0]);
         ins_cnt += bb.len;
     }
-    return EXECUTE_STATUS::SUCCESS;
 }

--- a/hart.cpp
+++ b/hart.cpp
@@ -20,3 +20,18 @@ EXECUTE_STATUS Hart::simulate() {
     }
     return EXECUTE_STATUS::SUCCESS;
 }
+
+EXECUTE_STATUS Hart::exec_instr() {
+    BasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
+    if (bb.addr == pc) {
+        bb.instrs[0].execute(this, bb.instrs[0]);
+        ins_cnt += bb.len;
+    }
+    else {
+        bb.construct((instT*)(memory+pc));
+        bb.addr = pc;
+        bb.instrs[0].execute(this, bb.instrs[0]);
+        ins_cnt += bb.len;
+    }
+    return EXECUTE_STATUS::SUCCESS;
+}

--- a/hart.cpp
+++ b/hart.cpp
@@ -2,6 +2,22 @@
 #include <iostream>
 #include "instruction.hpp"
 #include "basic_block.hpp"
+#include "jit.hpp"
+
+Hart::Hart(bool use_jit_)
+    : registers({}),
+      pc(0),
+      memory(nullptr),
+      done(false),
+      ins_cnt(0),
+      use_jit(use_jit_),
+      jit_arr(nullptr),
+      bbs_arr(nullptr) {
+    if (use_jit)
+        jit_arr = new RVJitBlock[Jit_arr_mask + 1]();
+    else
+        bbs_arr = new RVBasicBlock[BB_arr_mask + 1]();
+}
 
 EXECUTE_STATUS Hart::simulate() {
     EXECUTE_STATUS status = EXECUTE_STATUS::SUCCESS;
@@ -35,7 +51,7 @@ void Hart::bb_run_instr() {
 
 void Hart::jit_run_instr() {
     DEB("execjit");
-    RVBasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
+    RVJitBlock &bb = jit_arr[(pc >> 2) & Jit_arr_mask];
     DEB("decoding at pc=" << pc << " bb.addr=" << bb.addr);
     if (bb.addr == pc) {
         DEB("already jitted")

--- a/hart.cpp
+++ b/hart.cpp
@@ -1,18 +1,26 @@
 #include "hart.hpp"
+#include <iostream>
 #include "instruction.hpp"
 #include "basic_block.hpp"
 
 EXECUTE_STATUS Hart::simulate() {
     EXECUTE_STATUS status = EXECUTE_STATUS::SUCCESS;
     while (!done) {
-        DEB("decoding at pc=" << pc);
-        //jit_run_instr();
         exec_instr();
     }
     return EXECUTE_STATUS::SUCCESS;
 }
 
 void Hart::exec_instr() {
+    DEB("decoding at pc=" << pc);
+    if (use_jit)
+        jit_run_instr();
+    else
+        bb_run_instr();
+}
+
+void Hart::bb_run_instr() {
+    DEB("execbb");
     RVBasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
     if (bb.addr == pc) {
         bb.instrs[0].execute(this, bb.instrs[0]);
@@ -27,9 +35,11 @@ void Hart::exec_instr() {
 }
 
 void Hart::jit_run_instr() {
+    DEB("execjit");
     RVBasicBlock &bb = bbs_arr[(pc >> 2) & BB_arr_mask];
-    std::cout << "decoding at pc=" << pc << '\n';
+    DEB("decoding at pc=" << pc << " bb.addr=" << bb.addr);
     if (bb.addr == pc) {
+        DEB("already jitted")
         bb.jitted(this->registers.data(), this->memory, &this->pc, &this->done);
         ins_cnt += bb.len;
     } else {

--- a/hart.hpp
+++ b/hart.hpp
@@ -40,8 +40,22 @@ public:
     std::array<regT, REGISTERS_NUM> registers;
     uint8_t *memory;
     bool done;
+    bool use_jit;
 
-    Hart() : registers({}), pc(0), memory(nullptr), done(false), ins_cnt(0) { }
+    RVBasicBlock *bbs_arr;
+
+    Hart(bool use_jit_)
+        : registers({}),
+          pc(0),
+          memory(nullptr),
+          done(false),
+          ins_cnt(0),
+          use_jit(use_jit_),
+          bbs_arr(new RVBasicBlock[BB_arr_mask+1]()){}
+
+    ~Hart() {
+        delete[] bbs_arr;
+    }
 
     uint64_t get_reg(int ind) {
         return registers[ind];
@@ -54,6 +68,8 @@ public:
     EXECUTE_STATUS simulate();
 
     void exec_instr();
+
+    void bb_run_instr();
 
     void jit_run_instr();
 };

--- a/hart.hpp
+++ b/hart.hpp
@@ -41,9 +41,7 @@ public:
     uint8_t *memory;
     bool done;
 
-    Hart() : registers({}), pc(0), memory(nullptr), done(false), ins_cnt(0) {
-        fill_arrays();
-    }
+    Hart() : registers({}), pc(0), memory(nullptr), done(false), ins_cnt(0) { }
 
     uint64_t get_reg(int ind) {
         return registers[ind];

--- a/hart.hpp
+++ b/hart.hpp
@@ -4,6 +4,7 @@
 #include "instruction.hpp"
 #include "mask.hpp"
 #include "basic_block.hpp"
+#include "jit.hpp"
 
 #include <cstdint>
 #include <array>
@@ -43,18 +44,13 @@ public:
     bool use_jit;
 
     RVBasicBlock *bbs_arr;
+    RVJitBlock *jit_arr;
 
-    Hart(bool use_jit_)
-        : registers({}),
-          pc(0),
-          memory(nullptr),
-          done(false),
-          ins_cnt(0),
-          use_jit(use_jit_),
-          bbs_arr(new RVBasicBlock[BB_arr_mask+1]()){}
+    Hart(bool use_jit_);
 
     ~Hart() {
         delete[] bbs_arr;
+        delete[] jit_arr;
     }
 
     uint64_t get_reg(int ind) {

--- a/hart.hpp
+++ b/hart.hpp
@@ -53,7 +53,7 @@ public:
 
     EXECUTE_STATUS simulate();
 
-    EXECUTE_STATUS exec_instr();
+    void exec_instr();
 };
 
 #endif //HART_H

--- a/hart.hpp
+++ b/hart.hpp
@@ -41,7 +41,9 @@ public:
     uint8_t *memory;
     bool done;
 
-    Hart() : registers({}), pc(0), memory(nullptr), done(false), ins_cnt(0) { }
+    Hart() : registers({}), pc(0), memory(nullptr), done(false), ins_cnt(0) {
+        fill_arrays();
+    }
 
     uint64_t get_reg(int ind) {
         return registers[ind];

--- a/hart.hpp
+++ b/hart.hpp
@@ -52,6 +52,8 @@ public:
     }
 
     EXECUTE_STATUS simulate();
+
+    EXECUTE_STATUS exec_instr();
 };
 
 #endif //HART_H

--- a/instrs.h
+++ b/instrs.h
@@ -157,37 +157,37 @@ _INSTR_(ADDIW, I, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + IMM))}, true, {
 
 #define IRADDR IRCR(GEP, I8T, mem, IRCR(Add, LGET(RS1), LC64(IMM)))
 
-_INSTR_(LD, I, { SET_REG(RD, *(uint64_t*)MEM(REG(RS1)+IMM)); }, false, {
+_INSTR_(LD, I, { SET_REG(RD, *(uint64_t*)MEM(REG(RS1)+IMM)); }, true, {
     LSET(RD, IRCR(Load, I64PTR, IRADDR));
 })
-_INSTR_(LW, I, { SET_REG(RD, *(int32_t*)MEM(REG(RS1)+IMM)); }, false, {
+_INSTR_(LW, I, { SET_REG(RD, *(int32_t*)MEM(REG(RS1)+IMM)); }, true, {
     LSET(RD, IRCR(SExt, IRCR(Load, I32T, IRADDR), I64T));
 })
-_INSTR_(LWU, I, { SET_REG(RD, *(uint32_t*)MEM(REG(RS1)+IMM)); }, false, {
+_INSTR_(LWU, I, { SET_REG(RD, *(uint32_t*)MEM(REG(RS1)+IMM)); }, true, {
     LSET(RD, IRCR(ZExt, IRCR(Load, I32T, IRADDR), I64T));
 })
-_INSTR_(LH, I, { SET_REG(RD, *(int16_t*)MEM(REG(RS1)+IMM)); }, false, {
+_INSTR_(LH, I, { SET_REG(RD, *(int16_t*)MEM(REG(RS1)+IMM)); }, true, {
     LSET(RD, IRCR(SExt, IRCR(Load, I16T, IRADDR), I64T));
 })
-_INSTR_(LHU, I, { SET_REG(RD, *(uint16_t*)MEM(REG(RS1)+IMM)); }, false, {
+_INSTR_(LHU, I, { SET_REG(RD, *(uint16_t*)MEM(REG(RS1)+IMM)); }, true, {
     LSET(RD, IRCR(ZExt, IRCR(Load, I16T, IRADDR), I64T));
 })
-_INSTR_(LB, I, { SET_REG(RD, *(int8_t*)MEM(REG(RS1)+IMM)); }, false, {
+_INSTR_(LB, I, { SET_REG(RD, *(int8_t*)MEM(REG(RS1)+IMM)); }, true, {
     LSET(RD, IRCR(SExt, IRCR(Load, I8T, IRADDR), I64T));
 })
-_INSTR_(LBU, I, { SET_REG(RD, *(uint8_t*)MEM(REG(RS1)+IMM)); }, false, {
+_INSTR_(LBU, I, { SET_REG(RD, *(uint8_t*)MEM(REG(RS1)+IMM)); }, true, {
     LSET(RD, IRCR(ZExt, IRCR(Load, I8T, IRADDR), I64T));
 })
-_INSTR_(SD, S, { *(uint64_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
+_INSTR_(SD, S, { *(uint64_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, true, {
     IRCR(Store, LGET(RS2), IRADDR);
 })
-_INSTR_(SW, S, { *(uint32_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
+_INSTR_(SW, S, { *(uint32_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, true, {
     IRCR(Store,  IRCR(Trunc, LGET(RS2), I32T), IRADDR);
 })
-_INSTR_(SH, S, { *(uint16_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
+_INSTR_(SH, S, { *(uint16_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, true, {
     IRCR(Store,  IRCR(Trunc, LGET(RS2), I16T), IRADDR);
 })
-_INSTR_(SB, S, { *(uint8_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
+_INSTR_(SB, S, { *(uint8_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, true, {
     IRCR(Store,  IRCR(Trunc, LGET(RS2), I8T), IRADDR);
 })
 _INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false, { IRCR(Store, builder.getInt1(true), done); }) // WARNING same as ebreak // TODO add actuall functionality

--- a/instrs.h
+++ b/instrs.h
@@ -11,14 +11,15 @@
 #define REG(reg) (heart->get_reg(reg))
 #define SET_REG(reg, val) (heart->set_reg(reg, val)); DEB("set reg: " << REG(reg));
 
-#define LGET(reg) ( builder.CreateLoad(Type::getInt64Ty(ctx), \
-    builder.CreateConstGEP1_64(Type::getInt64PtrTy(ctx), regs, reg) ) )
-
-#define LSET(reg, val) builder.CreateStore(val,  \
-    builder.CreateConstGEP1_64(Type::getInt64PtrTy(ctx), regs, reg));
-
 #define LC64(num) builder.getInt64(num)
-#define LPC (builder.CreateLoad(Type::getInt64Ty(ctx), pc))
+
+#define LGET(reg) ( (reg) ? (builder.CreateLoad(Type::getInt64Ty(ctx), \
+    builder.CreateConstGEP1_64(Type::getInt64PtrTy(ctx), regs, reg), #reg "_" )) : ((Value*) LC64(0)) )
+
+#define LSET(reg, val) { if (reg) builder.CreateStore(val,  \
+    builder.CreateConstGEP1_64(Type::getInt64PtrTy(ctx), regs, reg, #reg "_" )); }
+
+#define LPC (builder.CreateLoad(Type::getInt64Ty(ctx), pc, "pc"))
 
 #define CODE_BIN_IU(op) SET_REG(RD, REG(RS1) op IMM);
 #define CODE_BIN_IS(op) SET_REG(RD, ((int64_t)REG(RS1)) op ((int64_t)IMM));
@@ -99,16 +100,22 @@ _INSTR_(SUBW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) - REG(RS2)))}, true, {
 _INSTR_(ADDW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + REG(RS2)))}, true, {
  LSET(RD, builder.CreateSExt( builder.CreateAdd( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx) ), LGET(RS2)) , Type::getInt64PtrTy(ctx)));
 }) // TODO check if it's correct but it should be nice
-_INSTR_(JAL, J, { NEW_PC = OPC + IMM; SET_REG(RD, OPC + 4); }, false, { builder.CreateStore(new_pc, builder.CreateAdd(LPC, LC64(IMM))); LSET(RD, builder.CreateAdd(LPC, LC64(4)));  })
-_INSTR_(JALR, I, { NEW_PC = (IMM + REG(RS1)) & ~1ULL; SET_REG(RD, OPC + 4); }, false, { builder.CreateStore(new_pc, builder.CreateAnd( builder.CreateAdd(LGET(RS1), LC64(IMM)), LC64(~1ULL))); LSET(RD, builder.CreateAdd(LPC, LC64(4))); })
+_INSTR_(JAL, J, { NEW_PC = OPC + IMM; SET_REG(RD, OPC + 4); }, false, { new_pc = builder.CreateAdd(LPC, LC64(IMM), "new_pc"); LSET(RD, builder.CreateAdd(LPC, LC64(4)));  })
+_INSTR_(JALR, I, { NEW_PC = (IMM + REG(RS1)) & ~1ULL; SET_REG(RD, OPC + 4); }, false, { new_pc = builder.CreateAnd( builder.CreateAdd(LGET(RS1), LC64(IMM)), LC64(~1ULL), "new_pc"); LSET(RD, builder.CreateAdd(LPC, LC64(4))); })
 
 #define JIT_COND_JMP(name) BasicBlock *trueBr = BasicBlock::Create(ctx, "", fn); \
-BasicBlock *retBr = BasicBlock::Create(ctx, "", fn); \
-builder.CreateCondBr(builder.CreateICmp##name(LGET(RS1), LGET(RS2)), trueBr, retBr); \
-builder.SetInsertPoint(trueBr); \
-builder.CreateStore(builder.CreateAdd(LPC, LC64(IMM)), new_pc); \
-builder.CreateBr(retBr); \
-builder.SetInsertPoint(retBr);
+    BasicBlock *retBr = BasicBlock::Create(ctx, "", fn); \
+    Value* old_new_pc = new_pc; \
+    BasicBlock* entryBlock = &fn->getEntryBlock(); \
+    builder.CreateCondBr(builder.CreateICmp##name(LGET(RS1), LGET(RS2)), trueBr, retBr); \
+    builder.SetInsertPoint(trueBr); \
+    new_pc = builder.CreateAdd(LPC, LC64(IMM), "new_pc"); \
+    builder.CreateBr(retBr); \
+    builder.SetInsertPoint(retBr); \
+    PHINode* phi = builder.CreatePHI(Type::getInt64Ty(ctx), 2, "new_pc_" #name); \
+    phi->addIncoming(old_new_pc, entryBlock); \
+    phi->addIncoming(new_pc, trueBr); \
+    new_pc = phi;
 
 _INSTR_(BEQ, B, {CODE_CJU(==)}, false, { JIT_COND_JMP(EQ) })
 _INSTR_(BNE, B, {CODE_CJU(!=)}, false, { JIT_COND_JMP(NE) })

--- a/instrs.h
+++ b/instrs.h
@@ -78,7 +78,6 @@ builder.SetInsertPoint(trueBr); \
 builder.CreateStore(builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc), LC64(IMM)), new_pc); \
 builder.CreateBr(retBr); \
 builder.SetInsertPoint(retBr); \
-builder.CreateRetVoid(); \
 })
 _INSTR_(BLTU, B, {CODE_CJU(<)}, false, {})
 _INSTR_(BGE, B, {CODE_CJS(>=)}, false, {})
@@ -96,4 +95,4 @@ _INSTR_(SD, S, { *(uint64_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {})
 _INSTR_(SW, S, { *(uint32_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {})
 _INSTR_(SH, S, { *(uint16_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {})
 _INSTR_(SB, S, { *(uint8_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {})
-_INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false, {}) // WARNING same as ebreak // TODO add actuall functionality
+_INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false, { builder.CreateStore(builder.getInt1(true), done); }) // WARNING same as ebreak // TODO add actuall functionality

--- a/instrs.h
+++ b/instrs.h
@@ -1,16 +1,23 @@
 #include "encoding.out.h"
-#include <cstdint>
 // #define _INSTR_(name, type, code, linear)
 
 #define RS1 (instr.rs1)
 #define RS2 (instr.rs2)
 #define RD (instr.rd)
 #define IMM (instr.imm)
-#define PC (heart->pc)
+#define OPC (heart->pc)
 #define NEW_PC (new_pc)
 #define MEM(ind) (heart->memory+(ind))
 #define REG(reg) (heart->get_reg(reg))
 #define SET_REG(reg, val) (heart->set_reg(reg, val)); DEB("set reg: " << REG(reg));
+
+#define LGET(reg) ( builder.CreateLoad(Type::getInt64Ty(ctx), \
+    builder.CreateConstGEP1_64(Type::getInt64PtrTy(ctx), regs, reg) ) )
+
+#define LSET(reg, val) builder.CreateStore(val, Type::getInt64Ty(ctx), \
+    builder.CreateConstGEP1_64(Type::getInt64PtrTy(ctx), regs, reg));
+
+#define LC64(num) builder.getInt64(num)
 
 #define CODE_BIN_IU(op) SET_REG(RD, REG(RS1) op IMM);
 #define CODE_BIN_IS(op) SET_REG(RD, ((int64_t)REG(RS1)) op ((int64_t)IMM));
@@ -18,66 +25,75 @@
 #define CODE_BIN_RU(op) SET_REG(RD, REG(RS1) op REG(RS2));
 #define CODE_BIN_RS(op) SET_REG(RD, ((int64_t)REG(RS1)) op ((int64_t)REG(RS2)));
 
-#define CODE_CJU(op) ((REG(RS1) op REG(RS2)) && (NEW_PC = PC + IMM));
-#define CODE_CJS(op) ((((int64_t)REG(RS1)) op ((int64_t)REG(RS2))) && (NEW_PC = PC + IMM));
+#define CODE_CJU(op) ((REG(RS1) op REG(RS2)) && (NEW_PC = OPC + IMM));
+#define CODE_CJS(op) ((((int64_t)REG(RS1)) op ((int64_t)REG(RS2))) && (NEW_PC = OPC + IMM));
 
 #define SIX_BITS ((1<<6)-1)
 #define FIV_BITS ((1<<5)-1)
 
-_INSTR_(SLTI, I, {CODE_BIN_IS(<)}, true)
-_INSTR_(SLTIU, I, {CODE_BIN_IU(<)}, true)
-_INSTR_(ADDI, I, {CODE_BIN_IU(+)}, true)
-_INSTR_(ANDI, I, {CODE_BIN_IU(&)}, true)
-_INSTR_(ORI, I, {CODE_BIN_IU(|)}, true)
-_INSTR_(XORI, I, {CODE_BIN_IU(^)}, true)
-_INSTR_(SLLI, I, {SET_REG(RD, REG(RS1) << (IMM & SIX_BITS))}, true) // TODO check
+_INSTR_(SLTI, I, {CODE_BIN_IS(<)}, true, {})
+_INSTR_(SLTIU, I, {CODE_BIN_IU(<)}, true, {})
+_INSTR_(ADDI, I, {CODE_BIN_IU(+)}, true, { LSET(RD, LC64(IMM) + LGET(RS1)); })
+_INSTR_(ANDI, I, {CODE_BIN_IU(&)}, true, {})
+_INSTR_(ORI, I, {CODE_BIN_IU(|)}, true, {})
+_INSTR_(XORI, I, {CODE_BIN_IU(^)}, true, {})
+_INSTR_(SLLI, I, {SET_REG(RD, REG(RS1) << (IMM & SIX_BITS))}, true, {}) // TODO check
 _INSTR_(SRLI, I, {SET_REG(RD,
                           !!(IMM & 1<<10)*(REG(RS1) >> (IMM & SIX_BITS)) // logical
                           |
                           !(IMM & 1<<10)*((int64_t)REG(RS1) >> (IMM & SIX_BITS)) // arithmetic
-)}, true) // TODO check for correctness // WARNING decoded same as SRAI
-_INSTR_(SLLIW, I, {SET_REG(RD, (uint32_t)REG(RS1) << (IMM & SIX_BITS))}, true) // TODO check
+)}, true, {}) // TODO check for correctness // WARNING decoded same as SRAI
+_INSTR_(SLLIW, I, {SET_REG(RD, (uint32_t)REG(RS1) << (IMM & SIX_BITS))}, true, {}) // TODO check
 _INSTR_(SRLIW, I, {SET_REG(RD,
                           !!(IMM & 1<<10)*((uint32_t)REG(RS1) >> (IMM & SIX_BITS)) // logical
                           |
                           !(IMM & 1<<10)*((int32_t)REG(RS1) >> (IMM & SIX_BITS)) // arithmetic
-)}, true) // TODO check for correctness // WARNING decoded same as SRAIW
-_INSTR_(LUI, U, { SET_REG(RD, (IMM&INSN_FIELD_IMM20)) }, true)
-_INSTR_(AUIPC, U,{ SET_REG(RD, (IMM + PC)) }, true) 
-_INSTR_(ADD, R, {CODE_BIN_RU(+)}, true)
-_INSTR_(SLT, R, {CODE_BIN_RS(<)}, true)
-_INSTR_(SLTU, R, {CODE_BIN_RU(<)}, true)
-_INSTR_(AND, R, {CODE_BIN_RU(&)}, true)
-_INSTR_(OR, R, {CODE_BIN_RU(|)}, true)
-_INSTR_(XOR, R, {CODE_BIN_RU(^)}, true)
-_INSTR_(SLL, R, {SET_REG(RD, REG(RS1) << (REG(RS2) & SIX_BITS))}, true) // TODO check
-_INSTR_(SRL, R, {SET_REG(RD, (REG(RS1) >> (REG(RS2) & SIX_BITS)))}, true) // TODO check
-_INSTR_(SRA, R, {SET_REG(RD, ((int64_t)REG(RS1) >> (REG(RS2) & SIX_BITS)))}, true) // TODO check
-_INSTR_(SLLW, R, {SET_REG(RD, (uint32_t)REG(RS1) << (REG(RS2) & FIV_BITS))}, true) // TODO check
-_INSTR_(SRLW, R, {SET_REG(RD, ((uint32_t)REG(RS1) >> (REG(RS2) & FIV_BITS)))}, true) // TODO check
-_INSTR_(SRAW, R, {SET_REG(RD, ((int32_t)REG(RS1) >> (REG(RS2) & FIV_BITS)))}, true) // TODO check
-_INSTR_(SUB, R, {CODE_BIN_RU(-)}, true)
-_INSTR_(SUBW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) - REG(RS2)))}, true) // TODO check if it's correct but it should be nice
-_INSTR_(ADDW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + REG(RS2)))}, true) // TODO check if it's correct but it should be nice
-_INSTR_(JAL, J, { NEW_PC = PC + IMM; SET_REG(RD, PC + 4); }, false)
-_INSTR_(JALR, I, { NEW_PC = (IMM + REG(RS1)) & ~1ULL; SET_REG(RD, PC + 4); }, false)
-_INSTR_(BEQ, B, {CODE_CJU(==)}, false)
-_INSTR_(BNE, B, {CODE_CJU(!=)}, false)
-_INSTR_(BLT, B, {CODE_CJS(<)}, false)
-_INSTR_(BLTU, B, {CODE_CJU(<)}, false)
-_INSTR_(BGE, B, {CODE_CJS(>=)}, false)
-_INSTR_(BGEU, B, {CODE_CJU(>=)}, false)
-_INSTR_(ADDIW, I, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + IMM))}, true) // TODO check if it's correct but it should be nice
+)}, true, {}) // TODO check for correctness // WARNING decoded same as SRAIW
+_INSTR_(LUI, U, { SET_REG(RD, (IMM&INSN_FIELD_IMM20)) }, true, {})
+_INSTR_(AUIPC, U,{ SET_REG(RD, (IMM + OPC)) }, true, {}) 
+_INSTR_(ADD, R, {CODE_BIN_RU(+)}, true, { LSET(RD, LGET(RS2) + LGET(RS1)); })
+_INSTR_(SLT, R, {CODE_BIN_RS(<)}, true, {})
+_INSTR_(SLTU, R, {CODE_BIN_RU(<)}, true, {})
+_INSTR_(AND, R, {CODE_BIN_RU(&)}, true, {})
+_INSTR_(OR, R, {CODE_BIN_RU(|)}, true, {})
+_INSTR_(XOR, R, {CODE_BIN_RU(^)}, true, {})
+_INSTR_(SLL, R, {SET_REG(RD, REG(RS1) << (REG(RS2) & SIX_BITS))}, true, {}) // TODO check
+_INSTR_(SRL, R, {SET_REG(RD, (REG(RS1) >> (REG(RS2) & SIX_BITS)))}, true, {}) // TODO check
+_INSTR_(SRA, R, {SET_REG(RD, ((int64_t)REG(RS1) >> (REG(RS2) & SIX_BITS)))}, true, {}) // TODO check
+_INSTR_(SLLW, R, {SET_REG(RD, (uint32_t)REG(RS1) << (REG(RS2) & FIV_BITS))}, true, {}) // TODO check
+_INSTR_(SRLW, R, {SET_REG(RD, ((uint32_t)REG(RS1) >> (REG(RS2) & FIV_BITS)))}, true, {}) // TODO check
+_INSTR_(SRAW, R, {SET_REG(RD, ((int32_t)REG(RS1) >> (REG(RS2) & FIV_BITS)))}, true, {}) // TODO check
+_INSTR_(SUB, R, {CODE_BIN_RU(-)}, true, {})
+_INSTR_(SUBW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) - REG(RS2)))}, true, {}) // TODO check if it's correct but it should be nice
+_INSTR_(ADDW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + REG(RS2)))}, true, {}) // TODO check if it's correct but it should be nice
+_INSTR_(JAL, J, { NEW_PC = OPC + IMM; SET_REG(RD, OPC + 4); }, false, {})
+_INSTR_(JALR, I, { NEW_PC = (IMM + REG(RS1)) & ~1ULL; SET_REG(RD, OPC + 4); }, false, {})
+_INSTR_(BEQ, B, {CODE_CJU(==)}, false, {})
+_INSTR_(BNE, B, {CODE_CJU(!=)}, false, {})
+_INSTR_(BLT, B, {CODE_CJS(<)}, false, {
+Value *trueBr = BasicBlock::Create(ctx, "", jit_fun);
+Value *retBr = BasicBlock::Create(ctx, "", jit_fun);
+builder.CreateICmpSLT(LGET(RS1), LGET(RS2), trueBr, retBr);
+builder.SetInsertPoint(trueBr);
+builder.CreateStore(builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc) Lc64(IMM)), new_pc);
+builder.CreateBr(falseBr);
+builder.SetInsertPoint(falseBr);
+builder.CreateRetVoid();
+})
+_INSTR_(BLTU, B, {CODE_CJU(<)}, false, {})
+_INSTR_(BGE, B, {CODE_CJS(>=)}, false, {})
+_INSTR_(BGEU, B, {CODE_CJU(>=)}, false, {})
+_INSTR_(ADDIW, I, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + IMM))}, true, {}) // TODO check if it's correct but it should be nice
 // TODO check type conversions
-_INSTR_(LD, I, { SET_REG(RD, *(uint64_t*)MEM(REG(RS1)+IMM)); }, false)
-_INSTR_(LW, I, { SET_REG(RD, *(int32_t*)MEM(REG(RS1)+IMM)); }, false)
-_INSTR_(LWU, I, { SET_REG(RD, *(uint32_t*)MEM(REG(RS1)+IMM)); }, false)
-_INSTR_(LH, I, { SET_REG(RD, *(int16_t*)MEM(REG(RS1)+IMM)); }, false)
-_INSTR_(LHU, I, { SET_REG(RD, *(uint16_t*)MEM(REG(RS1)+IMM)); }, false)
-_INSTR_(LB, I, { SET_REG(RD, *(int8_t*)MEM(REG(RS1)+IMM)); }, false)
-_INSTR_(LBU, I, { SET_REG(RD, *(uint8_t*)MEM(REG(RS1)+IMM)); }, false)
-_INSTR_(SD, S, { *(uint64_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false)
-_INSTR_(SW, S, { *(uint32_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false)
-_INSTR_(SH, S, { *(uint16_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false)
-_INSTR_(SB, S, { *(uint8_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false)
-_INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false) // WARNING same as ebreak // TODO add actuall functionality
+_INSTR_(LD, I, { SET_REG(RD, *(uint64_t*)MEM(REG(RS1)+IMM)); }, false, {})
+_INSTR_(LW, I, { SET_REG(RD, *(int32_t*)MEM(REG(RS1)+IMM)); }, false, {})
+_INSTR_(LWU, I, { SET_REG(RD, *(uint32_t*)MEM(REG(RS1)+IMM)); }, false, {})
+_INSTR_(LH, I, { SET_REG(RD, *(int16_t*)MEM(REG(RS1)+IMM)); }, false, {})
+_INSTR_(LHU, I, { SET_REG(RD, *(uint16_t*)MEM(REG(RS1)+IMM)); }, false, {})
+_INSTR_(LB, I, { SET_REG(RD, *(int8_t*)MEM(REG(RS1)+IMM)); }, false, {})
+_INSTR_(LBU, I, { SET_REG(RD, *(uint8_t*)MEM(REG(RS1)+IMM)); }, false, {})
+_INSTR_(SD, S, { *(uint64_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {})
+_INSTR_(SW, S, { *(uint32_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {})
+_INSTR_(SH, S, { *(uint16_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {})
+_INSTR_(SB, S, { *(uint8_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {})
+_INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false, {}) // WARNING same as ebreak // TODO add actuall functionality

--- a/instrs.h
+++ b/instrs.h
@@ -14,16 +14,22 @@
 #define I64PTR (Type::getInt64PtrTy(ctx))
 #define I64T (Type::getInt64Ty(ctx))
 #define I32PTR (Type::getInt32PtrTy(ctx))
+#define I32T (Type::getInt32Ty(ctx))
 #define I16PTR (Type::getInt16PtrTy(ctx))
+#define I16T (Type::getInt16Ty(ctx))
 #define I8PTR (Type::getInt8PtrTy(ctx))
+#define I8T (Type::getInt8Ty(ctx))
 
 #define IRCR(name, ...) builder.Create##name(__VA_ARGS__)
 #define IRGEP64(...) builder.CreateConstGEP1_64(I64PTR, __VA_ARGS__)
 
 #define LC64(num) builder.getInt64(num)
+#define LC32(num) builder.getInt32(num)
 
 #define LGET(reg) ( (reg) ? (IRCR(Load, I64T, IRGEP64(regs, reg), #reg "_" )) \
                           : ((Value*) LC64(0)) )
+
+#define LGET32(reg) IRCR(Trunc, LGET(reg), I32T)
 
 #define LSET(reg, val) {if (reg) IRCR(Store, val, IRGEP64(regs, reg, #reg "_"));}
 
@@ -63,18 +69,18 @@ _INSTR_(SRLI, I, {SET_REG(RD,
         LSET(RD, ans);
 }) // TODO check for correctness // WARNING decoded same as SRAI
 _INSTR_(SLLIW, I, {SET_REG(RD, (uint32_t)REG(RS1) << (IMM & SIX_BITS))}, true, {
-     LSET(RD, IRCR(ZExt, IRCR(Shl, IRCR(Trunc, LGET(RS1), I32PTR), LC64(IMM & SIX_BITS) ) , I64PTR));
+     LSET(RD, IRCR(ZExt, IRCR(Shl, LGET32(RS1), LC32(IMM & SIX_BITS)), I64PTR));
 }) // TODO check
 _INSTR_(SRLIW, I, {SET_REG(RD,
-                          !!(IMM & 1<<10)*((uint32_t)REG(RS1) >> (IMM & SIX_BITS)) // logical
-                          |
-                          !(IMM & 1<<10)*((int32_t)REG(RS1) >> (IMM & SIX_BITS)) // arithmetic
+    !!(IMM & 1<<10)*((uint32_t)REG(RS1) >> (IMM & SIX_BITS)) // logical
+    |
+    !(IMM & 1<<10)*((int32_t)REG(RS1) >> (IMM & SIX_BITS)) // arithmetic
 )}, true, {
     Value *ans=nullptr;
     if (IMM & 1<<10)
-         ans = IRCR(ZExt, IRCR(LShr, IRCR(Trunc, LGET(RS1), I32PTR), LC64(IMM & SIX_BITS)), I64PTR);
+         ans = IRCR(ZExt, IRCR(LShr, LGET32(RS1), LC32(IMM & SIX_BITS)), I64T);
     else
-         ans = IRCR(ZExt, IRCR(AShr, IRCR(Trunc, LGET(RS1), I32PTR), LC64(IMM & SIX_BITS)), I64PTR);
+         ans = IRCR(ZExt, IRCR(AShr, LGET32(RS1), LC32(IMM & SIX_BITS)), I64T);
     LSET(RD, ans);
 }) // TODO check for correctness // WARNING decoded same as SRAIW
 _INSTR_(LUI, U, { SET_REG(RD, (IMM&INSN_FIELD_IMM20)) }, true, { LSET(RD, LC64(IMM&INSN_FIELD_IMM20)); })
@@ -88,6 +94,7 @@ _INSTR_(SLTU, R, {CODE_BIN_RU(<)}, true, { JIT_BIN_OP(ICmpULT) })
 _INSTR_(AND, R, {CODE_BIN_RU(&)}, true, { JIT_BIN_OP(And) })
 _INSTR_(OR, R, {CODE_BIN_RU(|)}, true, { JIT_BIN_OP(Or) })
 _INSTR_(XOR, R, {CODE_BIN_RU(^)}, true, { JIT_BIN_OP(Xor) })
+
 _INSTR_(SLL, R, {SET_REG(RD, REG(RS1) << (REG(RS2) & SIX_BITS))}, true, {
     LSET(RD, IRCR(Shl, LGET(RS1), IRCR(And, LGET(RS2), LC64(SIX_BITS))))
 }) // TODO check
@@ -98,20 +105,20 @@ _INSTR_(SRA, R, {SET_REG(RD, ((int64_t)REG(RS1) >> (REG(RS2) & SIX_BITS)))}, tru
     LSET(RD, IRCR(AShr, LGET(RS1), IRCR(And, LGET(RS2), LC64(SIX_BITS))))
 }) // TODO check
 _INSTR_(SLLW, R, {SET_REG(RD, (uint32_t)REG(RS1) << (REG(RS2) & FIV_BITS))}, true, {
-    LSET(RD, IRCR(ZExt, IRCR(Shl, IRCR(Trunc, LGET(RS1), I32PTR), IRCR(And, LGET(RS2), LC64(FIV_BITS))), I64PTR));
+    LSET(RD, IRCR(ZExt, IRCR(Shl, LGET32(RS1), IRCR(And, LGET32(RS2), LC32(FIV_BITS))), I64T));
 }) // TODO check
 _INSTR_(SRLW, R, {SET_REG(RD, ((uint32_t)REG(RS1) >> (REG(RS2) & FIV_BITS)))}, true, {
-    LSET(RD, IRCR(ZExt, IRCR(LShr, IRCR(Trunc, LGET(RS1), I32PTR), IRCR(And, LGET(RS2), LC64(FIV_BITS))), I64PTR));
+    LSET(RD, IRCR(ZExt, IRCR(LShr, LGET32(RS1), IRCR(And, LGET32(RS2), LC32(FIV_BITS))), I64T));
 }) // TODO check
 _INSTR_(SRAW, R, {SET_REG(RD, ((int32_t)REG(RS1) >> (REG(RS2) & FIV_BITS)))}, true, {
-    LSET(RD, IRCR(ZExt, IRCR(AShr, IRCR(Trunc, LGET(RS1), I32PTR), IRCR(And, LGET(RS2), LC64(FIV_BITS))), I64PTR));
+    LSET(RD, IRCR(ZExt, IRCR(AShr, LGET32(RS1), IRCR(And, LGET32(RS2), LC32(FIV_BITS))), I64T));
 }) // TODO check
 _INSTR_(SUB, R, {CODE_BIN_RU(-)}, true, { JIT_BIN_OP(Sub) })
 _INSTR_(SUBW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) - REG(RS2)))}, true, {
-    LSET(RD, IRCR(SExt, IRCR(Sub, IRCR(Trunc, LGET(RS1), I32PTR), LGET(RS2)), I64PTR));
+    LSET(RD, IRCR(SExt, IRCR(Sub, LGET32(RS1), LGET32(RS2)), I64T));
 }) // TODO check if it's correct but it should be nice
 _INSTR_(ADDW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + REG(RS2)))}, true, {
-    LSET(RD, IRCR(SExt, IRCR(Add, IRCR(Trunc, LGET(RS1), I32PTR), LGET(RS2)), I64PTR));
+    LSET(RD, IRCR(SExt, IRCR(Add, LGET32(RS1), LGET32(RS2)), I64T));
 }) // TODO check if it's correct but it should be nice
 _INSTR_(JAL, J, { NEW_PC = OPC + IMM; SET_REG(RD, OPC + 4); }, false, {
     new_pc = IRCR(Add, LPC, LC64(IMM), "new_pc"); 
@@ -144,43 +151,43 @@ _INSTR_(BGE, B, {CODE_CJS(>=)}, false, { JIT_COND_JMP(SGE) })
 _INSTR_(BGEU, B, {CODE_CJU(>=)}, false, { JIT_COND_JMP(UGE) })
 
 _INSTR_(ADDIW, I, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + IMM))}, true, {
-    LSET(RD, IRCR(SExt, IRCR(Add, IRCR(Trunc, LGET(RS1), I32PTR), LC64(IMM)), I64PTR));
+    LSET(RD, IRCR(SExt, IRCR(Add, LGET32(RS1), LC32(IMM)), I64T));
 }) // TODO check if it's correct but it should be nice
 // TODO check type conversions
 
-#define IRADDR IRCR(GEP, I8PTR, mem, IRCR(Add, LGET(RS1), LC64(IMM)))
+#define IRADDR IRCR(GEP, I8T, mem, IRCR(Add, LGET(RS1), LC64(IMM)))
 
 _INSTR_(LD, I, { SET_REG(RD, *(uint64_t*)MEM(REG(RS1)+IMM)); }, false, {
     LSET(RD, IRCR(Load, I64PTR, IRADDR));
 })
 _INSTR_(LW, I, { SET_REG(RD, *(int32_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, IRCR(SExt, IRCR(Load, I32PTR, IRADDR), I64PTR));
+    LSET(RD, IRCR(SExt, IRCR(Load, I32T, IRADDR), I64T));
 })
 _INSTR_(LWU, I, { SET_REG(RD, *(uint32_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, IRCR(ZExt, IRCR(Load, I32PTR, IRADDR), I64PTR));
+    LSET(RD, IRCR(ZExt, IRCR(Load, I32T, IRADDR), I64T));
 })
 _INSTR_(LH, I, { SET_REG(RD, *(int16_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, IRCR(SExt, IRCR(Load, I16PTR, IRADDR), I64PTR));
+    LSET(RD, IRCR(SExt, IRCR(Load, I16T, IRADDR), I64T));
 })
 _INSTR_(LHU, I, { SET_REG(RD, *(uint16_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, IRCR(ZExt, IRCR(Load, I16PTR, IRADDR), I64PTR));
+    LSET(RD, IRCR(ZExt, IRCR(Load, I16T, IRADDR), I64T));
 })
 _INSTR_(LB, I, { SET_REG(RD, *(int8_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, IRCR(SExt, IRCR(Load, I8PTR, IRADDR), I64PTR));
+    LSET(RD, IRCR(SExt, IRCR(Load, I8T, IRADDR), I64T));
 })
 _INSTR_(LBU, I, { SET_REG(RD, *(uint8_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, IRCR(ZExt, IRCR(Load, I8PTR, IRADDR), I64PTR));
+    LSET(RD, IRCR(ZExt, IRCR(Load, I8T, IRADDR), I64T));
 })
 _INSTR_(SD, S, { *(uint64_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
     IRCR(Store, LGET(RS2), IRADDR);
 })
 _INSTR_(SW, S, { *(uint32_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    IRCR(Store,  IRCR(Trunc, LGET(RS2), I32PTR), IRADDR);
+    IRCR(Store,  IRCR(Trunc, LGET(RS2), I32T), IRADDR);
 })
 _INSTR_(SH, S, { *(uint16_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    IRCR(Store,  IRCR(Trunc, LGET(RS2), I16PTR), IRADDR);
+    IRCR(Store,  IRCR(Trunc, LGET(RS2), I16T), IRADDR);
 })
 _INSTR_(SB, S, { *(uint8_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    IRCR(Store,  IRCR(Trunc, LGET(RS2), I8PTR), IRADDR);
+    IRCR(Store,  IRCR(Trunc, LGET(RS2), I8T), IRADDR);
 })
 _INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false, { IRCR(Store, builder.getInt1(true), done); }) // WARNING same as ebreak // TODO add actuall functionality

--- a/instrs.h
+++ b/instrs.h
@@ -11,15 +11,23 @@
 #define REG(reg) (heart->get_reg(reg))
 #define SET_REG(reg, val) (heart->set_reg(reg, val)); DEB("set reg: " << REG(reg));
 
+#define I64PTR (Type::getInt64PtrTy(ctx))
+#define I64T (Type::getInt64Ty(ctx))
+#define I32PTR (Type::getInt32PtrTy(ctx))
+#define I16PTR (Type::getInt16PtrTy(ctx))
+#define I8PTR (Type::getInt8PtrTy(ctx))
+
+#define IRCR(name, ...) builder.Create##name(__VA_ARGS__)
+#define IRGEP64(...) builder.CreateConstGEP1_64(I64PTR, __VA_ARGS__)
+
 #define LC64(num) builder.getInt64(num)
 
-#define LGET(reg) ( (reg) ? (builder.CreateLoad(Type::getInt64Ty(ctx), \
-    builder.CreateConstGEP1_64(Type::getInt64PtrTy(ctx), regs, reg), #reg "_" )) : ((Value*) LC64(0)) )
+#define LGET(reg) ( (reg) ? (IRCR(Load, I64T, IRGEP64(regs, reg), #reg "_" )) \
+                          : ((Value*) LC64(0)) )
 
-#define LSET(reg, val) { if (reg) builder.CreateStore(val,  \
-    builder.CreateConstGEP1_64(Type::getInt64PtrTy(ctx), regs, reg, #reg "_" )); }
+#define LSET(reg, val) {if (reg) IRCR(Store, val, IRGEP64(regs, reg, #reg "_"));}
 
-#define LPC (builder.CreateLoad(Type::getInt64Ty(ctx), pc, "pc"))
+#define LPC (IRCR(Load, I64T, pc, "pc"))
 
 #define CODE_BIN_IU(op) SET_REG(RD, REG(RS1) op IMM);
 #define CODE_BIN_IS(op) SET_REG(RD, ((int64_t)REG(RS1)) op ((int64_t)IMM));
@@ -33,7 +41,7 @@
 #define SIX_BITS ((1<<6)-1)
 #define FIV_BITS ((1<<5)-1)
 
-#define JIT_BIN_IU(name) LSET(RD, builder.Create##name(LC64(IMM), LGET(RS1)));
+#define JIT_BIN_IU(name) LSET(RD, IRCR(name, LC64(IMM), LGET(RS1)));
 
 _INSTR_(SLTI, I, {CODE_BIN_IS(<)}, true, { JIT_BIN_IU(ICmpSLT) })
 _INSTR_(SLTIU, I, {CODE_BIN_IU(<)}, true, { JIT_BIN_IU(ICmpULT) })
@@ -43,36 +51,36 @@ _INSTR_(ORI, I, {CODE_BIN_IU(|)}, true, {JIT_BIN_IU(Or) })
 _INSTR_(XORI, I, {CODE_BIN_IU(^)}, true, {JIT_BIN_IU(Xor)})
 _INSTR_(SLLI, I, {SET_REG(RD, REG(RS1) << (IMM & SIX_BITS))}, true, { JIT_BIN_IU(Shl) }) // TODO check
 _INSTR_(SRLI, I, {SET_REG(RD,
-                          !!(IMM & 1<<10)*(REG(RS1) >> (IMM & SIX_BITS)) // logical
-                          |
-                          !(IMM & 1<<10)*((int64_t)REG(RS1) >> (IMM & SIX_BITS)) // arithmetic
-)}, true, { 
+      !!(IMM & 1<<10)*(REG(RS1) >> (IMM & SIX_BITS)) // logical
+      |
+      !(IMM & 1<<10)*((int64_t)REG(RS1) >> (IMM & SIX_BITS)) // arithmetic
+)}, true, {
         Value *ans=nullptr;
         if (IMM & 1<<10)
-            ans = builder.CreateLShr(LGET(RS1), LC64(IMM&SIX_BITS));
+            ans = IRCR(LShr, LGET(RS1), LC64(IMM&SIX_BITS));
         else
-            ans = builder.CreateAShr(LGET(RS1), LC64(IMM&SIX_BITS));
+            ans = IRCR(AShr, LGET(RS1), LC64(IMM&SIX_BITS));
         LSET(RD, ans);
 }) // TODO check for correctness // WARNING decoded same as SRAI
 _INSTR_(SLLIW, I, {SET_REG(RD, (uint32_t)REG(RS1) << (IMM & SIX_BITS))}, true, {
- LSET(RD, builder.CreateZExt( builder.CreateShl( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx) ), LC64(IMM & SIX_BITS) ) , Type::getInt64PtrTy(ctx)));
+     LSET(RD, IRCR(ZExt, IRCR(Shl, IRCR(Trunc, LGET(RS1), I32PTR), LC64(IMM & SIX_BITS) ) , I64PTR));
 }) // TODO check
 _INSTR_(SRLIW, I, {SET_REG(RD,
                           !!(IMM & 1<<10)*((uint32_t)REG(RS1) >> (IMM & SIX_BITS)) // logical
                           |
                           !(IMM & 1<<10)*((int32_t)REG(RS1) >> (IMM & SIX_BITS)) // arithmetic
 )}, true, {
-        Value *ans=nullptr;
-        if (IMM & 1<<10)
- ans = builder.CreateZExt( builder.CreateLShr( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx)), LC64(IMM & SIX_BITS) ) , Type::getInt64PtrTy(ctx));
-        else
- ans = builder.CreateZExt( builder.CreateAShr( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx)), LC64(IMM & SIX_BITS) ) , Type::getInt64PtrTy(ctx));
-        LSET(RD, ans);
-    }) // TODO check for correctness // WARNING decoded same as SRAIW
+    Value *ans=nullptr;
+    if (IMM & 1<<10)
+         ans = IRCR(ZExt, IRCR(LShr, IRCR(Trunc, LGET(RS1), I32PTR), LC64(IMM & SIX_BITS)), I64PTR);
+    else
+         ans = IRCR(ZExt, IRCR(AShr, IRCR(Trunc, LGET(RS1), I32PTR), LC64(IMM & SIX_BITS)), I64PTR);
+    LSET(RD, ans);
+}) // TODO check for correctness // WARNING decoded same as SRAIW
 _INSTR_(LUI, U, { SET_REG(RD, (IMM&INSN_FIELD_IMM20)) }, true, { LSET(RD, LC64(IMM&INSN_FIELD_IMM20)); })
-_INSTR_(AUIPC, U,{ SET_REG(RD, (IMM + OPC)) }, true, {LSET(RD, builder.CreateAdd(LC64(IMM), LPC));}) 
+_INSTR_(AUIPC, U,{ SET_REG(RD, (IMM + OPC)) }, true, {LSET(RD, IRCR(Add, LC64(IMM), LPC));}) 
 
-#define JIT_BIN_OP(name) LSET(RD, builder.Create##name(LGET(RS1), LGET(RS2)));
+#define JIT_BIN_OP(name) LSET(RD, IRCR(name, LGET(RS1), LGET(RS2)));
 
 _INSTR_(ADD, R, {CODE_BIN_RU(+)}, true, { JIT_BIN_OP(Add) })
 _INSTR_(SLT, R, {CODE_BIN_RS(<)}, true, { JIT_BIN_OP(ICmpSLT) })
@@ -80,39 +88,50 @@ _INSTR_(SLTU, R, {CODE_BIN_RU(<)}, true, { JIT_BIN_OP(ICmpULT) })
 _INSTR_(AND, R, {CODE_BIN_RU(&)}, true, { JIT_BIN_OP(And) })
 _INSTR_(OR, R, {CODE_BIN_RU(|)}, true, { JIT_BIN_OP(Or) })
 _INSTR_(XOR, R, {CODE_BIN_RU(^)}, true, { JIT_BIN_OP(Xor) })
-_INSTR_(SLL, R, {SET_REG(RD, REG(RS1) << (REG(RS2) & SIX_BITS))}, true, { LSET(RD, builder.CreateShl(LGET(RS1), builder.CreateAnd(LGET(RS2), LC64(SIX_BITS)))) }) // TODO check
-_INSTR_(SRL, R, {SET_REG(RD, (REG(RS1) >> (REG(RS2) & SIX_BITS)))}, true, { LSET(RD, builder.CreateLShr(LGET(RS1), builder.CreateAnd(LGET(RS2), LC64(SIX_BITS)))) }) // TODO check
-_INSTR_(SRA, R, {SET_REG(RD, ((int64_t)REG(RS1) >> (REG(RS2) & SIX_BITS)))}, true, { LSET(RD, builder.CreateAShr(LGET(RS1), builder.CreateAnd(LGET(RS2), LC64(SIX_BITS)))) }) // TODO check
+_INSTR_(SLL, R, {SET_REG(RD, REG(RS1) << (REG(RS2) & SIX_BITS))}, true, {
+    LSET(RD, IRCR(Shl, LGET(RS1), IRCR(And, LGET(RS2), LC64(SIX_BITS))))
+}) // TODO check
+_INSTR_(SRL, R, {SET_REG(RD, (REG(RS1) >> (REG(RS2) & SIX_BITS)))}, true, {
+    LSET(RD, IRCR(LShr, LGET(RS1), IRCR(And, LGET(RS2), LC64(SIX_BITS))))
+}) // TODO check
+_INSTR_(SRA, R, {SET_REG(RD, ((int64_t)REG(RS1) >> (REG(RS2) & SIX_BITS)))}, true, {
+    LSET(RD, IRCR(AShr, LGET(RS1), IRCR(And, LGET(RS2), LC64(SIX_BITS))))
+}) // TODO check
 _INSTR_(SLLW, R, {SET_REG(RD, (uint32_t)REG(RS1) << (REG(RS2) & FIV_BITS))}, true, {
-
- LSET(RD, builder.CreateZExt( builder.CreateShl( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx) ), builder.CreateAnd(LGET(RS2), LC64(FIV_BITS)) ) , Type::getInt64PtrTy(ctx)));
+    LSET(RD, IRCR(ZExt, IRCR(Shl, IRCR(Trunc, LGET(RS1), I32PTR), IRCR(And, LGET(RS2), LC64(FIV_BITS))), I64PTR));
 }) // TODO check
 _INSTR_(SRLW, R, {SET_REG(RD, ((uint32_t)REG(RS1) >> (REG(RS2) & FIV_BITS)))}, true, {
- LSET(RD, builder.CreateZExt( builder.CreateLShr( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx) ), builder.CreateAnd(LGET(RS2), LC64(FIV_BITS)) ) , Type::getInt64PtrTy(ctx)));
+    LSET(RD, IRCR(ZExt, IRCR(LShr, IRCR(Trunc, LGET(RS1), I32PTR), IRCR(And, LGET(RS2), LC64(FIV_BITS))), I64PTR));
 }) // TODO check
 _INSTR_(SRAW, R, {SET_REG(RD, ((int32_t)REG(RS1) >> (REG(RS2) & FIV_BITS)))}, true, {
- LSET(RD, builder.CreateZExt( builder.CreateAShr( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx) ), builder.CreateAnd(LGET(RS2), LC64(FIV_BITS)) ) , Type::getInt64PtrTy(ctx)));
+    LSET(RD, IRCR(ZExt, IRCR(AShr, IRCR(Trunc, LGET(RS1), I32PTR), IRCR(And, LGET(RS2), LC64(FIV_BITS))), I64PTR));
 }) // TODO check
 _INSTR_(SUB, R, {CODE_BIN_RU(-)}, true, { JIT_BIN_OP(Sub) })
 _INSTR_(SUBW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) - REG(RS2)))}, true, {
- LSET(RD, builder.CreateSExt( builder.CreateSub( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx) ), LGET(RS2)) , Type::getInt64PtrTy(ctx)));
+    LSET(RD, IRCR(SExt, IRCR(Sub, IRCR(Trunc, LGET(RS1), I32PTR), LGET(RS2)), I64PTR));
 }) // TODO check if it's correct but it should be nice
 _INSTR_(ADDW, R, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + REG(RS2)))}, true, {
- LSET(RD, builder.CreateSExt( builder.CreateAdd( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx) ), LGET(RS2)) , Type::getInt64PtrTy(ctx)));
+    LSET(RD, IRCR(SExt, IRCR(Add, IRCR(Trunc, LGET(RS1), I32PTR), LGET(RS2)), I64PTR));
 }) // TODO check if it's correct but it should be nice
-_INSTR_(JAL, J, { NEW_PC = OPC + IMM; SET_REG(RD, OPC + 4); }, false, { new_pc = builder.CreateAdd(LPC, LC64(IMM), "new_pc"); LSET(RD, builder.CreateAdd(LPC, LC64(4)));  })
-_INSTR_(JALR, I, { NEW_PC = (IMM + REG(RS1)) & ~1ULL; SET_REG(RD, OPC + 4); }, false, { new_pc = builder.CreateAnd( builder.CreateAdd(LGET(RS1), LC64(IMM)), LC64(~1ULL), "new_pc"); LSET(RD, builder.CreateAdd(LPC, LC64(4))); })
+_INSTR_(JAL, J, { NEW_PC = OPC + IMM; SET_REG(RD, OPC + 4); }, false, {
+    new_pc = IRCR(Add, LPC, LC64(IMM), "new_pc"); 
+    LSET(RD, IRCR(Add, LPC, LC64(4)));
+})
+_INSTR_(JALR, I, { NEW_PC = (IMM + REG(RS1)) & ~1ULL; SET_REG(RD, OPC + 4); }, false, {
+    new_pc = IRCR(And, IRCR(Add, LGET(RS1), LC64(IMM)), LC64(~1ULL), "new_pc");
+    LSET(RD, IRCR(Add, LPC, LC64(4)));
+})
 
 #define JIT_COND_JMP(name) BasicBlock *trueBr = BasicBlock::Create(ctx, "", fn); \
     BasicBlock *retBr = BasicBlock::Create(ctx, "", fn); \
     Value* old_new_pc = new_pc; \
     BasicBlock* entryBlock = &fn->getEntryBlock(); \
-    builder.CreateCondBr(builder.CreateICmp##name(LGET(RS1), LGET(RS2)), trueBr, retBr); \
+    IRCR(CondBr, IRCR(ICmp##name, LGET(RS1), LGET(RS2)), trueBr, retBr); \
     builder.SetInsertPoint(trueBr); \
-    new_pc = builder.CreateAdd(LPC, LC64(IMM), "new_pc"); \
+    new_pc = IRCR(Add, LPC, LC64(IMM), "new_pc"); \
     builder.CreateBr(retBr); \
     builder.SetInsertPoint(retBr); \
-    PHINode* phi = builder.CreatePHI(Type::getInt64Ty(ctx), 2, "new_pc_" #name); \
+    PHINode* phi = IRCR(PHI, I64T, 2, "new_pc_" #name); \
     phi->addIncoming(old_new_pc, entryBlock); \
     phi->addIncoming(new_pc, trueBr); \
     new_pc = phi;
@@ -123,60 +142,45 @@ _INSTR_(BLT, B, {CODE_CJS(<)}, false, { JIT_COND_JMP(SLT) })
 _INSTR_(BLTU, B, {CODE_CJU(<)}, false, { JIT_COND_JMP(ULT) })
 _INSTR_(BGE, B, {CODE_CJS(>=)}, false, { JIT_COND_JMP(SGE) })
 _INSTR_(BGEU, B, {CODE_CJU(>=)}, false, { JIT_COND_JMP(UGE) })
+
 _INSTR_(ADDIW, I, {SET_REG(RD, (int64_t)(int32_t)(REG(RS1) + IMM))}, true, {
- LSET(RD, builder.CreateSExt( builder.CreateAdd( builder.CreateTrunc( LGET(RS1), Type::getInt32PtrTy(ctx) ), LC64(IMM)) , Type::getInt64PtrTy(ctx)));
+    LSET(RD, IRCR(SExt, IRCR(Add, IRCR(Trunc, LGET(RS1), I32PTR), LC64(IMM)), I64PTR));
 }) // TODO check if it's correct but it should be nice
 // TODO check type conversions
-_INSTR_(LD, I, { SET_REG(RD, *(uint64_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, builder.CreateLoad(Type::getInt64PtrTy(ctx), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM)))));
-})
 
+#define IRADDR IRCR(GEP, I8PTR, mem, IRCR(Add, LGET(RS1), LC64(IMM)))
+
+_INSTR_(LD, I, { SET_REG(RD, *(uint64_t*)MEM(REG(RS1)+IMM)); }, false, {
+    LSET(RD, IRCR(Load, I64PTR, IRADDR));
+})
 _INSTR_(LW, I, { SET_REG(RD, *(int32_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, builder.CreateSExt(
-        builder.CreateLoad(Type::getInt32PtrTy(ctx), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM)))),
-        Type::getInt64PtrTy(ctx)
-    ));
+    LSET(RD, IRCR(SExt, IRCR(Load, I32PTR, IRADDR), I64PTR));
 })
 _INSTR_(LWU, I, { SET_REG(RD, *(uint32_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, builder.CreateZExt(
-        builder.CreateLoad(Type::getInt32PtrTy(ctx), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM)))),
-        Type::getInt64PtrTy(ctx)
-    ));
+    LSET(RD, IRCR(ZExt, IRCR(Load, I32PTR, IRADDR), I64PTR));
 })
 _INSTR_(LH, I, { SET_REG(RD, *(int16_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, builder.CreateSExt(
-        builder.CreateLoad(Type::getInt16PtrTy(ctx), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM)))),
-        Type::getInt64PtrTy(ctx)
-    ));
+    LSET(RD, IRCR(SExt, IRCR(Load, I16PTR, IRADDR), I64PTR));
 })
 _INSTR_(LHU, I, { SET_REG(RD, *(uint16_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, builder.CreateZExt(
-        builder.CreateLoad(Type::getInt16PtrTy(ctx), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM)))),
-        Type::getInt64PtrTy(ctx)
-    ));
+    LSET(RD, IRCR(ZExt, IRCR(Load, I16PTR, IRADDR), I64PTR));
 })
 _INSTR_(LB, I, { SET_REG(RD, *(int8_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, builder.CreateSExt(
-        builder.CreateLoad(Type::getInt8PtrTy(ctx), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM)))),
-        Type::getInt64PtrTy(ctx)
-    ));
+    LSET(RD, IRCR(SExt, IRCR(Load, I8PTR, IRADDR), I64PTR));
 })
 _INSTR_(LBU, I, { SET_REG(RD, *(uint8_t*)MEM(REG(RS1)+IMM)); }, false, {
-    LSET(RD, builder.CreateZExt(
-        builder.CreateLoad(Type::getInt8PtrTy(ctx), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM)))),
-        Type::getInt64PtrTy(ctx)
-    ));
+    LSET(RD, IRCR(ZExt, IRCR(Load, I8PTR, IRADDR), I64PTR));
 })
 _INSTR_(SD, S, { *(uint64_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    builder.CreateStore(LGET(RS2), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM))));
+    IRCR(Store, LGET(RS2), IRADDR);
 })
 _INSTR_(SW, S, { *(uint32_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt32PtrTy(ctx)), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM))));
+    IRCR(Store,  IRCR(Trunc, LGET(RS2), I32PTR), IRADDR);
 })
 _INSTR_(SH, S, { *(uint16_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt16PtrTy(ctx)), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM))));
+    IRCR(Store,  IRCR(Trunc, LGET(RS2), I16PTR), IRADDR);
 })
 _INSTR_(SB, S, { *(uint8_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt8PtrTy(ctx)), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM))));
+    IRCR(Store,  IRCR(Trunc, LGET(RS2), I8PTR), IRADDR);
 })
-_INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false, { builder.CreateStore(builder.getInt1(true), done); }) // WARNING same as ebreak // TODO add actuall functionality
+_INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false, { IRCR(Store, builder.getInt1(true), done); }) // WARNING same as ebreak // TODO add actuall functionality

--- a/instrs.h
+++ b/instrs.h
@@ -162,15 +162,15 @@ _INSTR_(LBU, I, { SET_REG(RD, *(uint8_t*)MEM(REG(RS1)+IMM)); }, false, {
     ));
 })
 _INSTR_(SD, S, { *(uint64_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    builder.CreateStore(LGET(RS2), builder.CreateAdd(LGET(RS1), LC64(IMM)));
+    builder.CreateStore(LGET(RS2), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM))));
 })
 _INSTR_(SW, S, { *(uint32_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt32PtrTy(ctx)), builder.CreateAdd(LGET(RS1), LC64(IMM)));
+    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt32PtrTy(ctx)), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM))));
 })
 _INSTR_(SH, S, { *(uint16_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt16PtrTy(ctx)), builder.CreateAdd(LGET(RS1), LC64(IMM)));
+    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt16PtrTy(ctx)), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM))));
 })
 _INSTR_(SB, S, { *(uint8_t*)MEM(REG(RS1)+IMM) = REG(RS2); }, false, {
-    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt8PtrTy(ctx)), builder.CreateAdd(LGET(RS1), LC64(IMM)));
+    builder.CreateStore( builder.CreateTrunc(LGET(RS2), Type::getInt8PtrTy(ctx)), builder.CreateGEP(Type::getInt8PtrTy(ctx), mem, builder.CreateAdd(LGET(RS1), LC64(IMM))));
 })
 _INSTR_(ECALL, I, {printf("Ecall or ebreak: doing exit...\n"); heart->done = true;}, false, { builder.CreateStore(builder.getInt1(true), done); }) // WARNING same as ebreak // TODO add actuall functionality

--- a/instrs.h
+++ b/instrs.h
@@ -87,7 +87,7 @@ _INSTR_(SRLIW, I, {SET_REG(RD,
 _INSTR_(LUI, U, { SET_REG(RD, (IMM&INSN_FIELD_IMM20)) }, true, { LSET(RD, LC64(IMM&INSN_FIELD_IMM20)); })
 _INSTR_(AUIPC, U,{ SET_REG(RD, (IMM + OPC)) }, true, {LSET(RD, IRCR(Add, LC64(IMM), LPC));}) 
 
-#define JIT_BIN_OP(name) LSET(RD, IRCR(name, LGET(RS1), LGET(RS2)));
+#define JIT_BIN_OP(name) LSET(RD, IRCR(ZExt, IRCR(name, LGET(RS1), LGET(RS2)), I64T));
 
 _INSTR_(ADD, R, {CODE_BIN_RU(+)}, true, { JIT_BIN_OP(Add) })
 _INSTR_(SLT, R, {CODE_BIN_RS(<)}, true, { JIT_BIN_OP(ICmpSLT) })

--- a/instrs.h
+++ b/instrs.h
@@ -34,7 +34,7 @@
 
 #define LSET(reg, val) {if (reg) IRCR(Store, val, IRGEP64(regs, reg, #reg "_"));}
 
-#define LPC (IRCR(Load, I64T, pc, "pc"))
+#define LPC pc //IRCR(Load, I64T, pc, "pc"))
 
 #define CODE_BIN_IU(op) DEB((int64_t)REG(RS1) << ' ' << IMM)  SET_REG(RD, REG(RS1) op IMM); DEB(REG(RD));
 #define CODE_BIN_IS(op) SET_REG(RD, ((int64_t)REG(RS1)) op ((int64_t)IMM));

--- a/instrs.h
+++ b/instrs.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "encoding.out.h"
 // #define _INSTR_(name, type, code, linear)
 
@@ -35,7 +36,7 @@
 
 #define LPC (IRCR(Load, I64T, pc, "pc"))
 
-#define CODE_BIN_IU(op) SET_REG(RD, REG(RS1) op IMM);
+#define CODE_BIN_IU(op) DEB((int64_t)REG(RS1) << ' ' << IMM)  SET_REG(RD, REG(RS1) op IMM); DEB(REG(RD));
 #define CODE_BIN_IS(op) SET_REG(RD, ((int64_t)REG(RS1)) op ((int64_t)IMM));
 
 #define CODE_BIN_RU(op) SET_REG(RD, REG(RS1) op REG(RS2));
@@ -47,7 +48,7 @@
 #define SIX_BITS ((1<<6)-1)
 #define FIV_BITS ((1<<5)-1)
 
-#define JIT_BIN_IU(name) LSET(RD, IRCR(name, LC64(IMM), LGET(RS1)));
+#define JIT_BIN_IU(name) LSET(RD, IRCR(ZExt, IRCR(name, LGET(RS1), LC64(IMM)), I64T));
 
 _INSTR_(SLTI, I, {CODE_BIN_IS(<)}, true, { JIT_BIN_IU(ICmpSLT) })
 _INSTR_(SLTIU, I, {CODE_BIN_IU(<)}, true, { JIT_BIN_IU(ICmpULT) })

--- a/instruction.cpp
+++ b/instruction.cpp
@@ -64,6 +64,8 @@ __attribute__((noinline)) void exec_##name(Hart *heart, const Instruction &instr
 
 #include "instrs.h"
 #undef _INSTR_
+#undef EXEC_RET_false
+#undef EXEC_RET_true
 
 };
 
@@ -77,11 +79,15 @@ using llvm::Value;
 using llvm::BasicBlock;
 using llvm::Function;
 
+#define EXEC_RET_true  
+#define EXEC_RET_false builder.CreateRetVoid();
+
 #define _INSTR_(name, type, code, linear, jit) \
-void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn) { \
+void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn, Value *done) { \
     builder.CreateStore(builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc), builder.getInt64(4)), new_pc); \
     jit  \
     builder.CreateStore(builder.CreateLoad(Type::getInt64Ty(ctx), new_pc), pc); \
+    EXEC_RET_##linear \
 }
 
 #include "instrs.h"

--- a/instruction.cpp
+++ b/instruction.cpp
@@ -78,16 +78,17 @@ using llvm::Type;
 using llvm::Value;
 using llvm::BasicBlock;
 using llvm::Function;
+using llvm::PHINode;
 
-#define EXEC_RET_true  
+#define EXEC_RET_true
 #define EXEC_RET_false builder.CreateRetVoid();
 
 #define _INSTR_(name, type, code, linear, jit) \
-void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn, Value *done) { \
+void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Function *fn, Value *done) { \
 std::cout << "dec " #name "\n"; \
-    builder.CreateStore(builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc), builder.getInt64(4)), new_pc); \
+    Value* new_pc = builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc, "pc"), builder.getInt64(4), "new_pc"); \
     jit  \
-    builder.CreateStore(builder.CreateLoad(Type::getInt64Ty(ctx), new_pc), pc); \
+    builder.CreateStore(new_pc, pc); \
     EXEC_RET_##linear \
 }
 

--- a/instruction.cpp
+++ b/instruction.cpp
@@ -84,6 +84,7 @@ using llvm::Function;
 
 #define _INSTR_(name, type, code, linear, jit) \
 void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn, Value *done) { \
+std::cout << "dec " #name "\n"; \
     builder.CreateStore(builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc), builder.getInt64(4)), new_pc); \
     jit  \
     builder.CreateStore(builder.CreateLoad(Type::getInt64Ty(ctx), new_pc), pc); \

--- a/instruction.cpp
+++ b/instruction.cpp
@@ -1,5 +1,6 @@
 #include "instruction.hpp"
 #include "hart.hpp"
+#include <llvm-16/llvm/IR/IRBuilder.h>
 
 void decode_instruction_R(Instruction &ins, instT code) {
     DEB("decs R");
@@ -54,11 +55,30 @@ void empty_executor(Hart *hart, const Instruction &instr) {
 #define EXEC_RET_true (&instr+1)->execute(heart, *(&instr+1))
 #define EXEC_RET_false 
 
-#define _INSTR_(name, type, code, linear) \
+#define _INSTR_(name, type, code, linear, jit) \
 __attribute__((noinline)) void exec_##name(Hart *heart, const Instruction &instr) { \
     DEB("exec "#name); \
     {int new_pc = heart->pc+4; code; heart->pc = new_pc;} \
     EXEC_RET_##linear; }
+
+#include "instrs.h"
+#undef _INSTR_
+
+};
+
+namespace Jiters {
+void empty_jiter(Instruction &instr, llvm::IRBuilder<> &builder) {
+    builder.CreateRetVoid();
+} // for basic blocks
+
+using llvm::Type;
+using llvm::Value;
+
+#define _INSTR_(name, type, code, linear, jit) \
+void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc) { \
+    jit  \
+builder.CreateStore(builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc), builder.getInt64(4)), new_pc); \
+}
 
 #include "instrs.h"
 #undef _INSTR_

--- a/instruction.cpp
+++ b/instruction.cpp
@@ -1,5 +1,6 @@
 #include "instruction.hpp"
 #include "hart.hpp"
+#include <llvm-16/llvm/IR/Function.h>
 #include <llvm-16/llvm/IR/IRBuilder.h>
 
 void decode_instruction_R(Instruction &ins, instT code) {
@@ -73,11 +74,14 @@ void empty_jiter(Instruction &instr, llvm::IRBuilder<> &builder) {
 
 using llvm::Type;
 using llvm::Value;
+using llvm::BasicBlock;
+using llvm::Function;
 
 #define _INSTR_(name, type, code, linear, jit) \
-void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc) { \
+void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn) { \
+    builder.CreateStore(builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc), builder.getInt64(4)), new_pc); \
     jit  \
-builder.CreateStore(builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc), builder.getInt64(4)), new_pc); \
+    builder.CreateStore(builder.CreateLoad(Type::getInt64Ty(ctx), new_pc), pc); \
 }
 
 #include "instrs.h"

--- a/instruction.cpp
+++ b/instruction.cpp
@@ -85,7 +85,7 @@ using llvm::PHINode;
 
 #define _INSTR_(name, type, code, linear, jit) \
 void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Function *fn, Value *done) { \
-std::cout << "dec " #name "\n"; \
+    DEB("dec " #name); \
     Value* new_pc = builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc, "pc"), builder.getInt64(4), "new_pc"); \
     jit  \
     builder.CreateStore(new_pc, pc); \

--- a/instruction.cpp
+++ b/instruction.cpp
@@ -70,7 +70,7 @@ __attribute__((noinline)) void exec_##name(Hart *heart, const Instruction &instr
 };
 
 namespace Jiters {
-void empty_jiter(Instruction &instr, llvm::IRBuilder<> &builder) {
+void empty_jiter(llvm::IRBuilder<> &builder) {
     builder.CreateRetVoid();
 } // for basic blocks
 

--- a/instruction.cpp
+++ b/instruction.cpp
@@ -70,7 +70,8 @@ __attribute__((noinline)) void exec_##name(Hart *heart, const Instruction &instr
 };
 
 namespace Jiters {
-void empty_jiter(llvm::IRBuilder<> &builder) {
+void empty_jiter(llvm::IRBuilder<> &builder, Value *new_pc, Value *pc_ptr) {
+    builder.CreateStore(new_pc, pc_ptr);
     builder.CreateRetVoid();
 } // for basic blocks
 
@@ -80,16 +81,12 @@ using llvm::BasicBlock;
 using llvm::Function;
 using llvm::PHINode;
 
-#define EXEC_RET_true
-#define EXEC_RET_false builder.CreateRetVoid();
-
 #define _INSTR_(name, type, code, linear, jit) \
-void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Function *fn, Value *done) { \
+Value *jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Function *fn, Value *done) { \
     DEB("dec " #name); \
-    Value* new_pc = builder.CreateAdd(builder.CreateLoad(Type::getInt64Ty(ctx), pc, "pc"), builder.getInt64(4), "new_pc"); \
+    Value* new_pc = builder.CreateAdd(pc, builder.getInt64(4), "new_pc"); \
     jit  \
-    builder.CreateStore(new_pc, pc); \
-    EXEC_RET_##linear \
+    return new_pc; \
 }
 
 #include "instrs.h"

--- a/instruction.hpp
+++ b/instruction.hpp
@@ -74,7 +74,7 @@ using llvm::Value;
 using llvm::Function;
 
 #define _INSTR_(name, type, code, linear, jit) \
-void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn, Value *done);
+void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Function *fn, Value *done);
 
 #include "instrs.h"
 #undef _INSTR_

--- a/instruction.hpp
+++ b/instruction.hpp
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <iostream>
 #include <functional>
+#include <llvm-16/llvm/IR/IRBuilder.h>
+#include <llvm-16/llvm/IR/Value.h>
 #include "encoding.out.h"
 
 #define RD_SHIFT 7
@@ -55,8 +57,22 @@ namespace Executors {
 void empty_executor(Hart *heart, const Instruction &instr); // for basic blocks
 
 
-#define _INSTR_(name, type, code, linear) \
+#define _INSTR_(name, type, code, linear, jit) \
 void exec_##name(Hart *heart, const Instruction &instr);
+
+#include "instrs.h"
+#undef _INSTR_
+
+};
+
+namespace Jiters {
+void empty_jiter(Instruction &instr, llvm::IRBuilder<> &builder); // for basic blocks
+
+using llvm::Type;
+using llvm::Value;
+
+#define _INSTR_(name, type, code, linear, jit) \
+void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc);
 
 #include "instrs.h"
 #undef _INSTR_

--- a/instruction.hpp
+++ b/instruction.hpp
@@ -74,7 +74,7 @@ using llvm::Value;
 using llvm::Function;
 
 #define _INSTR_(name, type, code, linear, jit) \
-void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn);
+void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn, Value *done);
 
 #include "instrs.h"
 #undef _INSTR_

--- a/instruction.hpp
+++ b/instruction.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <iostream>
 #include <functional>
+#include <llvm-16/llvm/IR/Function.h>
 #include <llvm-16/llvm/IR/IRBuilder.h>
 #include <llvm-16/llvm/IR/Value.h>
 #include "encoding.out.h"
@@ -70,9 +71,10 @@ void empty_jiter(Instruction &instr, llvm::IRBuilder<> &builder); // for basic b
 
 using llvm::Type;
 using llvm::Value;
+using llvm::Function;
 
 #define _INSTR_(name, type, code, linear, jit) \
-void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc);
+void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Value *new_pc, Function *fn);
 
 #include "instrs.h"
 #undef _INSTR_

--- a/instruction.hpp
+++ b/instruction.hpp
@@ -71,14 +71,14 @@ void exec_##name(Hart *heart, const Instruction &instr);
 };
 
 namespace Jiters {
-void empty_jiter(llvm::IRBuilder<> &builder); // for basic blocks
+void empty_jiter(llvm::IRBuilder<> &builder, llvm::Value *new_pc, llvm::Value *pc_ptr);
 
 using llvm::Type;
 using llvm::Value;
 using llvm::Function;
 
 #define _INSTR_(name, type, code, linear, jit) \
-void jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Function *fn, Value *done);
+Value *jit_##name(Instruction &instr, llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx, Value* regs, Value *mem, Value *pc, Function *fn, Value *done);
 
 #include "instrs.h"
 #undef _INSTR_

--- a/instruction.hpp
+++ b/instruction.hpp
@@ -35,6 +35,10 @@ public:
     Instruction(instT code, executorT execute_) : execute(execute_) {}
     Instruction() {}
 
+    void dump() {
+        std::cout << (int)rs1 << ' ' << (int)rs2 << ' ' << (int)rd << ' ' << (int)imm << '\n';
+    }
+
     instT instr_code;
     regIDT rs1, rs2, rd;
     uint64_t imm;
@@ -67,7 +71,7 @@ void exec_##name(Hart *heart, const Instruction &instr);
 };
 
 namespace Jiters {
-void empty_jiter(Instruction &instr, llvm::IRBuilder<> &builder); // for basic blocks
+void empty_jiter(llvm::IRBuilder<> &builder); // for basic blocks
 
 using llvm::Type;
 using llvm::Value;

--- a/jit.cpp
+++ b/jit.cpp
@@ -1,0 +1,107 @@
+#include "llvm/ExecutionEngine/Interpreter.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/TargetSelect.h"
+#include <llvm-16/llvm/IR/DerivedTypes.h>
+#include <string>
+
+#include "instruction.hpp"
+#include "hart.hpp"
+#include "jit.hpp"
+
+using namespace llvm;
+using namespace llvm::orc;
+
+static llvm::Expected<std::unique_ptr<llvm::orc::LLJIT>> jit = nullptr;
+static llvm::LLVMContext ctx;
+static llvm::FunctionType *jit_ft;
+
+void RVJitBlock::init() {
+    InitializeNativeTarget();
+    InitializeNativeTargetAsmPrinter();
+    InitializeNativeTargetAsmParser();
+
+    jit = LLJITBuilder().create();
+    if (!jit) {
+        std::cerr << "Failed to create LLJIT: " << toString(jit.takeError()) << std::endl;
+        exit(1);
+    }
+    jit_ft =
+        FunctionType::get(Type::getVoidTy(ctx),
+                          {Type::getInt64PtrTy(ctx), Type::getInt8PtrTy(ctx),
+                           Type::getInt64PtrTy(ctx), Type::getInt1PtrTy(ctx)},
+                          false);
+}
+
+size_t RVJitBlock::do_jit(const instT *arr) {
+    static int cnt = 0;
+    cnt++;
+    const std::string name = std::to_string(cnt);
+    auto module = std::make_unique<Module>(name, ctx);
+    Function* fn = Function::Create(jit_ft, Function::ExternalLinkage, name, module.get());
+    BasicBlock* block = BasicBlock::Create(ctx, "", fn);
+    IRBuilder<> builder(block);
+
+    auto args = fn->args().begin();
+    Value* regs = &*args++;
+    Value* mem = &*args++;
+    Value* pc_ptr = &*args++;
+    Value* done = &*args;
+
+    Value *pc_val = builder.CreateLoad(Type::getInt64Ty(ctx), pc_ptr, "pc");
+
+    int i = 0;
+    for (; i < JIT_LEN; i++) {
+        DEB("bb:" << i);
+        const instT &instruction = arr[i];
+        DEB("bb:" << instruction);
+        uint32_t fingerprint = instruction & mask[instruction & 127];
+        DEB("bb:" << i);
+        fingerprint = FP_HASH(fingerprint);
+
+        DEB("reading...");
+        auto dec = decoders[fingerprint];
+        DEB("decoding..");
+        dec.decod(instrs[i], instruction);
+        pc_val = dec.jit(instrs[i], builder, ctx, regs, mem, pc_val, fn, done);
+#ifdef DEBUG
+        instrs[i].dump();
+#endif
+        if (!dec.linear)
+            break;
+    }
+    len = i + 1;
+    Jiters::empty_jiter(builder, pc_val, pc_ptr);
+
+#ifdef DEBUG
+    module->print(outs(), nullptr);
+#endif
+    DEB("printed");
+
+    bool verif = verifyModule(*module, &outs());
+    DEB("[VERIFICATION] " << (!verif ? "OK\n\n" : "FAIL\n"));
+
+
+    if (auto err = jit->get()->addIRModule(ThreadSafeModule(std::move(module), std::make_unique<LLVMContext>()))) {
+        std::cerr << "Failed to add module to LLJIT: " << toString(std::move(err)) << std::endl;
+        return 1;
+    }
+
+    DEB(jit->get() << " no err");
+    // Look up the JIT'd function, cast it to a function pointer, then call it.
+    auto jit_func_sym = jit->get()->lookup(name);
+    DEB(jit->get() << " no err");
+    if (!jit_func_sym) {
+        std::cerr << "Failed to look up function: " << toString(jit_func_sym.takeError()) << std::endl;
+        return 1;
+    }
+
+    DEB("looked up");
+    // Cast the symbol's address to a function pointer and call it.
+    jitted = jit_func_sym->toPtr<BBFType>();
+    DEB("casted");
+    return JIT_LEN+1;
+}

--- a/jit.hpp
+++ b/jit.hpp
@@ -1,0 +1,25 @@
+#ifndef JIT_H
+#define JIT_H
+
+#include "instruction.hpp"
+#include "mask.hpp"
+#include <cstdint>
+#include <llvm-16/llvm/IR/DerivedTypes.h>
+#include <llvm-16/llvm/IR/Type.h>
+
+const size_t JIT_LEN = 31; // 1 for cosim, 31 is good enough for run
+const size_t Jit_arr_mask = (1<<17)-1; // TODO it's 90MB, maybe more?
+
+class RVJitBlock {
+public:
+    typedef void (*BBFType)(uint64_t *regs, uint8_t *mem, size_t *pc, bool *done);
+    size_t addr;
+    BBFType jitted;
+    Instruction instrs[JIT_LEN+1]; // +1 is reserved for empty
+    uint8_t len;
+
+    static void init();
+    size_t do_jit(const instT *arr);
+};
+
+#endif // JIT_H

--- a/main.cpp
+++ b/main.cpp
@@ -88,6 +88,7 @@ void run_8q() {
         return;
     }
 
+    std::cout << "STACK POINTER " << hart.registers[2] << " VMEM SIZE " << reader.vmem_size << '\n';
     auto start = std::chrono::steady_clock::now();
 
     hart.simulate();

--- a/main.cpp
+++ b/main.cpp
@@ -88,7 +88,6 @@ void run_8q() {
         return;
     }
 
-    std::cout << "STACK POINTER " << hart.registers[2] << " VMEM SIZE " << reader.vmem_size << '\n';
     auto start = std::chrono::steady_clock::now();
 
     hart.simulate();

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 //#define DEBUG
 
 #include "hart.hpp"
+#include "basic_block.hpp"
 #include "elf_reader.hpp"
 
 #include <cstdint>
@@ -84,6 +85,7 @@ void run_8q() {
 }
 
 int main() {
+    RVBasicBlock::init();
     if (test_fib_imm() and test_elf_reader())
         std::cout << "tests are OK!\n";
     else {

--- a/main.cpp
+++ b/main.cpp
@@ -61,6 +61,10 @@ bool test_elf_reader() {
         return false;
     }
     hart.simulate();
+    std::cout << (hart.registers[20] )
+        << (hart.registers[11])
+        << (hart.registers[12] )
+        << (hart.registers[13] ) << '\n';
     bool status = (hart.registers[20] == 10)
         and (hart.registers[11] == 20)
         and (hart.registers[12] == 30)

--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,7 @@
 #include "hart.hpp"
 #include "basic_block.hpp"
 #include "elf_reader.hpp"
+#include "jit.hpp"
 
 #include <cstdint>
 #include <vector>
@@ -196,7 +197,7 @@ void run_8q() {
 
 int main() {
     DEB("starting")
-    RVBasicBlock::init();
+    RVJitBlock::init();
     DEB("innited")
     fill_arrays();
     DEB("filled")

--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,52 @@
 
 #include <chrono>
 
+template<typename T1, typename T2>
+bool check_states(T1 &sim1, T2 &sim2) {
+    static uint32_t regs1[32];
+    static uint32_t regs2[32];
+
+    for (int i = 0; i < 32; i++) {
+        if (regs1[i] != (uint32_t)sim1.registers[i]) {
+            #ifdef DEBUG
+            std::cout << "RegChange of sim1's x" << i << " "
+                      << regs1[i] << " to " << (uint32_t)sim1.registers[i] << '\n';
+            #endif
+            regs1[i] = sim1.registers[i];
+        }
+
+        if ((uint32_t)sim1.registers[i] != (uint32_t)sim2.registers[i]) {
+            std::cerr << "reg " << i << " has different values!\n";
+            std::cerr << std::hex << sim1.registers[i] << ' ' << sim2.registers[i] << '\n';
+            return false;
+        }
+    }
+    return true;
+}
+
+template<typename T1, typename T2>
+bool cosim_sims(T1 &sim1, T2 &sim2) {
+    int cnt = 0;
+    bool cosim_ok = true;
+
+    do { // TODO: check infinite loop
+        sim1.exec_instr();
+        sim2.exec_instr();
+    } while (!sim1.done and !sim2.done and (cosim_ok = check_states(sim1, sim2)));
+
+    if (sim1.done != sim2.done) {
+        std::cerr << "done has different states!\n";
+        cosim_ok = false;
+    }
+
+    if (cosim_ok)
+        std::cout << "Cosim is ALL GOOD!\n";
+    else
+        std::cout << "Cosim failed :(\n";
+    return cosim_ok;
+}
+
+
 bool test_fib_imm() {
     // fibonacci
     /*
@@ -26,7 +72,11 @@ lop:
 // answer is in x3
 */
 
-    Hart hart;
+    DEB("starting fib")
+    Hart hartj(true);
+    DEB("innited jit")
+    Hart hartb(false);
+    DEB("innited bb")
     std::vector<uint32_t> fib = {
         0x00000000,
         0x00200393,
@@ -42,11 +92,14 @@ lop:
         0x00000073 // ecall
     };
 
-    hart.memory = (uint8_t*)fib.data();
-    hart.pc = 4;
-    hart.simulate();
-    std::cout << "fib(9): " << hart.registers[3] << " (34=>ok)\n";
-    if (hart.registers[3] != 34) {
+    hartj.memory = (uint8_t*)fib.data();
+    hartj.pc = 4;
+    hartb.memory = (uint8_t*)fib.data();
+    hartb.pc = 4;
+
+    cosim_sims(hartb, hartj);
+    std::cout << "fib(9): " << hartj.registers[3] << " (34=>ok)\n";
+    if (hartj.registers[3] != 34) {
         std::cerr << "Fibonacci test from array was not passed!!!\n";
         return false;
     }
@@ -54,23 +107,27 @@ lop:
 }
 
 bool test_elf_reader() {
-    Hart hart;
+    Hart hartj(true);
+    Hart hartb(false);
+
     ElfReader reader("build/sample_rv64");
-    ReaderStatus read_st = reader.load_instructions(hart);
-    if (read_st != ReaderStatus::SUCCESS) {
+    ReaderStatus read_st = reader.load_instructions(hartb);
+    ReaderStatus read_st2 = reader.load_instructions(hartj);
+    if (read_st != ReaderStatus::SUCCESS or read_st2 != ReaderStatus::SUCCESS) {
         std::cout << "failed to load instrs, ELF LOAD test failed :(\n";
         std::cout << "load err: " << int(read_st) << '\n';
         return false;
     }
-    hart.simulate();
-    std::cout << (hart.registers[20] )
-        << (hart.registers[11])
-        << (hart.registers[12] )
-        << (hart.registers[13] ) << '\n';
-    bool status = (hart.registers[20] == 10)
-        and (hart.registers[11] == 20)
-        and (hart.registers[12] == 30)
-        and (hart.registers[13] == 10);
+
+    cosim_sims(hartb, hartj);
+    std::cout << (hartb.registers[20] )
+        << (hartb.registers[11])
+        << (hartb.registers[12] )
+        << (hartb.registers[13] ) << '\n';
+    bool status = (hartb.registers[20] == 10)
+        and (hartb.registers[11] == 20)
+        and (hartb.registers[12] == 30)
+        and (hartb.registers[13] == 10);
     if (!status) {
         std::cerr << "read elf test was not passed!!!\n";
         return false;
@@ -79,9 +136,12 @@ bool test_elf_reader() {
 }
 
 void run_8q() {
-    Hart hart;
+    Hart hartj(true);
+    Hart hartb(false);
+
     ElfReader reader("build/8queens");
-    ReaderStatus read_st = reader.load_instructions(hart);
+    ReaderStatus read_st = reader.load_instructions(hartb);
+    ReaderStatus read_st2 = reader.load_instructions(hartj);
     if (read_st != ReaderStatus::SUCCESS) {
         std::cout << "failed to load instrs, ELF LOAD test failed :(\n";
         std::cout << "load err: " << int(read_st) << '\n';
@@ -90,19 +150,22 @@ void run_8q() {
 
     auto start = std::chrono::steady_clock::now();
 
-    hart.simulate();
+    cosim_sims(hartb, hartj);
 
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> elapsed = end - start;
 
     std::cout << "Time taken: " << elapsed.count() << " ms" << std::endl;
-    std::cout << "Intructions executed: " << hart.ins_cnt << std::endl;
-    std::cout << "Performance total: " << (hart.ins_cnt / elapsed.count()) / 1e3 << " Mips" << std::endl;
+    std::cout << "Intructions executed: " << hartb.ins_cnt << std::endl;
+    std::cout << "Performance total: " << (hartb.ins_cnt / elapsed.count()) / 1e3 << " Mips" << std::endl;
 }
 
 int main() {
+    DEB("starting")
     RVBasicBlock::init();
+    DEB("innited")
     fill_arrays();
+    DEB("filled")
 
     if (test_fib_imm() and test_elf_reader())
         std::cout << "tests are OK!\n";

--- a/main.cpp
+++ b/main.cpp
@@ -43,8 +43,7 @@ lop:
 
     hart.memory = (uint8_t*)fib.data();
     hart.pc = 4;
-    while (!hart.done)
-        hart.exec_instr();
+    hart.simulate();
     std::cout << "fib(9): " << hart.registers[3] << " (34=>ok)\n";
     if (hart.registers[3] != 34) {
         std::cerr << "Fibonacci test from array was not passed!!!\n";
@@ -62,8 +61,7 @@ bool test_elf_reader() {
         std::cout << "load err: " << int(read_st) << '\n';
         return false;
     }
-    while (!hart.done)
-        hart.exec_instr();
+    hart.simulate();
     bool status = (hart.registers[20] == 10)
         and (hart.registers[11] == 20)
         and (hart.registers[12] == 30)
@@ -87,8 +85,7 @@ void run_8q() {
 
     auto start = std::chrono::steady_clock::now();
 
-    while (!hart.done)
-        hart.exec_instr();
+    hart.simulate();
 
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> elapsed = end - start;
@@ -99,6 +96,8 @@ void run_8q() {
 }
 
 int main() {
+    fill_arrays();
+
     if (test_fib_imm() and test_elf_reader())
         std::cout << "tests are OK!\n";
     else {

--- a/main.cpp
+++ b/main.cpp
@@ -43,7 +43,8 @@ lop:
 
     hart.memory = (uint8_t*)fib.data();
     hart.pc = 4;
-    hart.simulate();
+    while (!hart.done)
+        hart.exec_instr();
     std::cout << "fib(9): " << hart.registers[3] << " (34=>ok)\n";
     if (hart.registers[3] != 34) {
         std::cerr << "Fibonacci test from array was not passed!!!\n";
@@ -61,7 +62,8 @@ bool test_elf_reader() {
         std::cout << "load err: " << int(read_st) << '\n';
         return false;
     }
-    hart.simulate();
+    while (!hart.done)
+        hart.exec_instr();
     bool status = (hart.registers[20] == 10)
         and (hart.registers[11] == 20)
         and (hart.registers[12] == 30)
@@ -85,7 +87,8 @@ void run_8q() {
 
     auto start = std::chrono::steady_clock::now();
 
-    hart.simulate();
+    while (!hart.done)
+        hart.exec_instr();
 
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> elapsed = end - start;

--- a/main.cpp
+++ b/main.cpp
@@ -9,6 +9,8 @@
 
 #include <chrono>
 
+//#define COSIM
+
 template<typename T1, typename T2>
 bool check_states(T1 &sim1, T2 &sim2) {
     static uint32_t regs1[32];
@@ -16,10 +18,8 @@ bool check_states(T1 &sim1, T2 &sim2) {
 
     for (int i = 0; i < 32; i++) {
         if (regs1[i] != (uint32_t)sim1.registers[i]) {
-            #ifdef DEBUG
-            std::cout << "RegChange of sim1's x" << i << " "
-                      << regs1[i] << " to " << (uint32_t)sim1.registers[i] << '\n';
-            #endif
+            DEB("RegChange of sim1's x" << i << " " << regs1[i] << " to "
+                                        << (uint32_t)sim1.registers[i]);
             regs1[i] = sim1.registers[i];
         }
 
@@ -50,7 +50,7 @@ bool cosim_sims(T1 &sim1, T2 &sim2) {
     if (cosim_ok)
         std::cout << "Cosim is ALL GOOD!\n";
     else
-        std::cout << "Cosim failed :(\n";
+        std::cerr << "Cosim failed :(\n";
     return cosim_ok;
 }
 
@@ -75,8 +75,12 @@ lop:
     DEB("starting fib")
     Hart hartj(true);
     DEB("innited jit")
+
+#ifdef COSIM
     Hart hartb(false);
     DEB("innited bb")
+#endif
+
     std::vector<uint32_t> fib = {
         0x00000000,
         0x00200393,
@@ -94,10 +98,17 @@ lop:
 
     hartj.memory = (uint8_t*)fib.data();
     hartj.pc = 4;
+#ifdef COSIM
     hartb.memory = (uint8_t*)fib.data();
     hartb.pc = 4;
+#endif
 
-    cosim_sims(hartb, hartj);
+#ifdef COSIM
+    if (not cosim_sims(hartb, hartj)) return false;
+#else
+    hartj.simulate();
+#endif
+
     std::cout << "fib(9): " << hartj.registers[3] << " (34=>ok)\n";
     if (hartj.registers[3] != 34) {
         std::cerr << "Fibonacci test from array was not passed!!!\n";
@@ -108,26 +119,38 @@ lop:
 
 bool test_elf_reader() {
     Hart hartj(true);
+#ifdef COSIM
     Hart hartb(false);
+    DEB("innited bb")
+#endif
 
     ElfReader reader("build/sample_rv64");
+#ifdef COSIM
     ReaderStatus read_st = reader.load_instructions(hartb);
+#else
+    ReaderStatus read_st = ReaderStatus::SUCCESS;
+#endif
     ReaderStatus read_st2 = reader.load_instructions(hartj);
     if (read_st != ReaderStatus::SUCCESS or read_st2 != ReaderStatus::SUCCESS) {
-        std::cout << "failed to load instrs, ELF LOAD test failed :(\n";
-        std::cout << "load err: " << int(read_st) << '\n';
+        std::cerr << "failed to load instrs, ELF LOAD test failed :(\n";
+        std::cerr << "load err: " << int(read_st) << '\n';
         return false;
     }
 
-    cosim_sims(hartb, hartj);
-    std::cout << (hartb.registers[20] )
-        << (hartb.registers[11])
-        << (hartb.registers[12] )
-        << (hartb.registers[13] ) << '\n';
-    bool status = (hartb.registers[20] == 10)
-        and (hartb.registers[11] == 20)
-        and (hartb.registers[12] == 30)
-        and (hartb.registers[13] == 10);
+#ifdef COSIM
+    if (not cosim_sims(hartb, hartj)) return false;
+#else
+    hartj.simulate();
+#endif
+
+    std::cout << (hartj.registers[20] )
+        << (hartj.registers[11])
+        << (hartj.registers[12] )
+        << (hartj.registers[13] ) << '\n';
+    bool status = (hartj.registers[20] == 10)
+        and (hartj.registers[11] == 20)
+        and (hartj.registers[12] == 30)
+        and (hartj.registers[13] == 10);
     if (!status) {
         std::cerr << "read elf test was not passed!!!\n";
         return false;
@@ -137,12 +160,19 @@ bool test_elf_reader() {
 
 void run_8q() {
     Hart hartj(true);
+#ifdef COSIM
     Hart hartb(false);
+    DEB("innited bb")
+#endif
 
     ElfReader reader("build/8queens");
+#ifdef COSIM
     ReaderStatus read_st = reader.load_instructions(hartb);
+#else
+    ReaderStatus read_st = ReaderStatus::SUCCESS;
+#endif
     ReaderStatus read_st2 = reader.load_instructions(hartj);
-    if (read_st != ReaderStatus::SUCCESS) {
+    if (read_st != ReaderStatus::SUCCESS or read_st2 != ReaderStatus::SUCCESS) {
         std::cout << "failed to load instrs, ELF LOAD test failed :(\n";
         std::cout << "load err: " << int(read_st) << '\n';
         return;
@@ -150,14 +180,18 @@ void run_8q() {
 
     auto start = std::chrono::steady_clock::now();
 
-    cosim_sims(hartb, hartj);
+#ifdef COSIM
+    if (not cosim_sims(hartb, hartj)) return;
+#else
+    hartj.simulate();
+#endif
 
     auto end = std::chrono::steady_clock::now();
     std::chrono::duration<double, std::milli> elapsed = end - start;
 
     std::cout << "Time taken: " << elapsed.count() << " ms" << std::endl;
-    std::cout << "Intructions executed: " << hartb.ins_cnt << std::endl;
-    std::cout << "Performance total: " << (hartb.ins_cnt / elapsed.count()) / 1e3 << " Mips" << std::endl;
+    std::cout << "Intructions executed: " << hartj.ins_cnt << std::endl;
+    std::cout << "Performance total: " << (hartj.ins_cnt / elapsed.count()) / 1e3 << " Mips" << std::endl;
 }
 
 int main() {
@@ -170,7 +204,7 @@ int main() {
     if (test_fib_imm() and test_elf_reader())
         std::cout << "tests are OK!\n";
     else {
-        std::cout << "tests are bad :(\n";
+        std::cerr << "tests are bad :(\n";
         return 1;
     }
 

--- a/mask.cpp
+++ b/mask.cpp
@@ -11,7 +11,7 @@ uint32_t mask[128] = {
 
 
 Decode decoders[(1<<18)-1] = {
-#define _INSTR_(name, type, code, linear, jit) [FP_HASH(MATCH_##name)] = {Executors::exec_##name, decode_instruction_##type, linear, jit},
+#define _INSTR_(name, type, code, linear, jit) [FP_HASH(MATCH_##name)] = {Executors::exec_##name, decode_instruction_##type, linear, Jiters::jit_##name},
 #include "instrs.h"
 #undef _INSTR_
 };

--- a/mask.cpp
+++ b/mask.cpp
@@ -11,7 +11,7 @@ uint32_t mask[128] = {
 
 
 Decode decoders[(1<<18)-1] = {
-#define _INSTR_(name, type, code, linear) [FP_HASH(MATCH_##name)] = {Executors::exec_##name, decode_instruction_##type, linear},
+#define _INSTR_(name, type, code, linear, jit) [FP_HASH(MATCH_##name)] = {Executors::exec_##name, decode_instruction_##type, linear, jit},
 #include "instrs.h"
 #undef _INSTR_
 };

--- a/mask.cpp
+++ b/mask.cpp
@@ -3,16 +3,18 @@
 #include "encoding.out.h"
 #include "mask.hpp"
 
-uint32_t mask[128] = {
-#define _INSTR_(name, ...) [(MATCH_##name & 127)] = MASK_##name,
+uint32_t mask[128];
+
+Decode decoders[(1<<18)-1];
+
+void fill_arrays() {
+#define _INSTR_(name, ...) mask[(MATCH_##name & 127)] = MASK_##name;
 #include "instrs.h"
 #undef _INSTR_
-};
 
-
-Decode decoders[(1<<18)-1] = {
-#define _INSTR_(name, type, code, linear) [FP_HASH(MATCH_##name)] = {Executors::exec_##name, decode_instruction_##type, linear},
+#define _INSTR_(name, type, code, linear) decoders[FP_HASH(MATCH_##name)] = {Executors::exec_##name, decode_instruction_##type, linear};
 #include "instrs.h"
 #undef _INSTR_
-};
+
+}
 

--- a/mask.hpp
+++ b/mask.hpp
@@ -3,7 +3,10 @@
 
 #include "instruction.hpp"
 #include <cstdint>
+#include <llvm-16/llvm/IR/Function.h>
 #include <llvm-16/llvm/IR/IRBuilder.h>
+#include <llvm-16/llvm/IR/Value.h>
+
 
 #define FP_HASH(x) ((x) & INSN_FIELD_OPCODE) \
                 | (((x) & INSN_FIELD_FUNCT3) >> 5) \
@@ -15,7 +18,8 @@ struct Decode {
     Instruction::executorT exec;
     void (*decod)(Instruction&, instT);
     bool linear;
-    void (*jit)(Instruction&, llvm::IRBuilder<>&);
+    void (*jit)(Instruction &, llvm::IRBuilder<> &, llvm::LLVMContext &, llvm::Value* , 
+                llvm::Value *, llvm::Value *, llvm::Value *new_pc, llvm::Function *fn);
 };
 
 extern Decode decoders[(1<<18)-1];

--- a/mask.hpp
+++ b/mask.hpp
@@ -3,6 +3,7 @@
 
 #include "instruction.hpp"
 #include <cstdint>
+#include <llvm-16/llvm/IR/IRBuilder.h>
 
 #define FP_HASH(x) ((x) & INSN_FIELD_OPCODE) \
                 | (((x) & INSN_FIELD_FUNCT3) >> 5) \
@@ -14,6 +15,7 @@ struct Decode {
     Instruction::executorT exec;
     void (*decod)(Instruction&, instT);
     bool linear;
+    void (*jit)(Instruction&, llvm::IRBuilder<>&);
 };
 
 extern Decode decoders[(1<<18)-1];

--- a/mask.hpp
+++ b/mask.hpp
@@ -19,7 +19,7 @@ struct Decode {
     void (*decod)(Instruction&, instT);
     bool linear;
     void (*jit)(Instruction &, llvm::IRBuilder<> &, llvm::LLVMContext &, llvm::Value* , 
-                llvm::Value *, llvm::Value *, llvm::Value *new_pc, llvm::Function *fn);
+                llvm::Value *, llvm::Value *, llvm::Value *new_pc, llvm::Function *fn, llvm::Value *done);
 };
 
 extern Decode decoders[(1<<18)-1];

--- a/mask.hpp
+++ b/mask.hpp
@@ -19,7 +19,7 @@ struct Decode {
     void (*decod)(Instruction&, instT);
     bool linear;
     void (*jit)(Instruction &, llvm::IRBuilder<> &, llvm::LLVMContext &, llvm::Value* , 
-                llvm::Value *, llvm::Value *, llvm::Value *new_pc, llvm::Function *fn, llvm::Value *done);
+                llvm::Value *, llvm::Value *, llvm::Function *fn, llvm::Value *done);
 };
 
 extern Decode decoders[(1<<18)-1];

--- a/mask.hpp
+++ b/mask.hpp
@@ -18,7 +18,7 @@ struct Decode {
     Instruction::executorT exec;
     void (*decod)(Instruction&, instT);
     bool linear;
-    void (*jit)(Instruction &, llvm::IRBuilder<> &, llvm::LLVMContext &, llvm::Value* , 
+    llvm::Value *(*jit)(Instruction &, llvm::IRBuilder<> &, llvm::LLVMContext &, llvm::Value* ,
                 llvm::Value *, llvm::Value *, llvm::Function *fn, llvm::Value *done);
 };
 

--- a/mask.hpp
+++ b/mask.hpp
@@ -18,4 +18,6 @@ struct Decode {
 
 extern Decode decoders[(1<<18)-1];
 
+void fill_arrays();
+
 #endif // MASK_H


### PR DESCRIPTION
Merge full support of llvm jit into main
- cosimulation was added (per-basic-block or per-instruction register comparison)
- was tested on our tests in main and 8queens 
- on my machine speedup is from 340 MIPS to 850 MIPS = x2.5

Maybe codestyle can be better but i'll do it later maybe in another MR, it seems fine overall